### PR TITLE
plat: Add support for Qualcomm Kodiak platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,7 @@ jobs:
           _make PLATFORM=telechips-tcc805x
           _make PLATFORM=versal2
           _make PLATFORM=versal2 CFG_AMD_PS_GPIO=y
+          _make PLATFORM=qcom-kodiak
 
           export ARCH=riscv
           unset CROSS_COMPILE32

--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -1,0 +1,27 @@
+# Qualcomm platform support
+
+PLATFORM_FLAVOR ?= kodiak
+
+$(call force,CFG_GIC,y)
+$(call force,CFG_ARM_GICV3,y)
+$(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
+$(call force,CFG_ARM64_core,y)
+$(call force,CFG_WITH_ARM_TRUSTED_FW,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,40)
+$(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
+$(call force,CFG_CORE_RESERVED_SHM,n)
+$(call force,CFG_QCOM_GENI_UART,y)
+
+ta-targets = ta_arm64
+supported-ta-targets ?= ta_arm64
+
+ifeq ($(PLATFORM_FLAVOR),kodiak)
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,8)
+
+CFG_TZDRAM_START ?= 0x1c300000
+CFG_TEE_RAM_VA_SIZE ?= 0x200000
+CFG_TA_RAM_VA_SIZE ?= 0x1c00000
+CFG_TZDRAM_SIZE  ?= (CFG_TEE_RAM_VA_SIZE + CFG_TA_RAM_VA_SIZE)
+CFG_NUM_THREADS  ?= 8
+endif

--- a/core/arch/arm/plat-qcom/main.c
+++ b/core/arch/arm/plat-qcom/main.c
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Linaro Limited
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <console.h>
+#include <drivers/gic.h>
+#include <drivers/qcom_geni_uart.h>
+#include <io.h>
+#include <kernel/boot.h>
+#include <platform_config.h>
+
+/*
+ * Register the physical memory area for peripherals etc. Here we are
+ * registering the UART console.
+ */
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, GENI_UART_REG_BASE,
+			GENI_UART_REG_SIZE);
+
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE, GIC_DIST_REG_SIZE);
+
+register_ddr(DRAM0_BASE, DRAM0_SIZE);
+#ifdef DRAM1_BASE
+register_ddr(DRAM1_BASE, DRAM1_SIZE);
+#endif
+
+static struct qcom_geni_uart_data console_data;
+
+void plat_console_init(void)
+{
+	qcom_geni_uart_init(&console_data, GENI_UART_REG_BASE);
+	register_serial_console(&console_data.chip);
+}
+
+void boot_primary_init_intc(void)
+{
+	gic_init_v3(0, GICD_BASE, GICR_BASE);
+}
+
+void boot_secondary_init_intc(void)
+{
+	gic_init_per_cpu();
+}

--- a/core/arch/arm/plat-qcom/platform_config.h
+++ b/core/arch/arm/plat-qcom/platform_config.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Linaro Limited
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef PLATFORM_CONFIG_H
+#define PLATFORM_CONFIG_H
+
+#include <mm/generic_ram_layout.h>
+
+/* Make stacks aligned to data cache line length */
+#define STACK_ALIGNMENT			64
+
+#if defined(PLATFORM_FLAVOR_kodiak)
+#define DRAM0_BASE			UL(0x80000000)
+#define DRAM0_SIZE			UL(0x80000000)
+#define DRAM1_BASE			ULL(0x100000000)
+#define DRAM1_SIZE			ULL(0x100000000)
+
+#define GENI_UART_REG_BASE		UL(0x994000)
+
+/* GIC related constants */
+#define GICD_BASE			UL(0x17a00000)
+#define GICR_BASE			UL(0x17a60000)
+#endif
+
+#endif /*PLATFORM_CONFIG_H*/

--- a/core/arch/arm/plat-qcom/sub.mk
+++ b/core/arch/arm/plat-qcom/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += .
+srcs-y += main.c

--- a/core/drivers/qcom_geni_uart.c
+++ b/core/drivers/qcom_geni_uart.c
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Qualcomm GENI serial engine UART driver
+ *
+ * Copyright (c) 2025, Linaro Limited
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <drivers/qcom_geni_uart.h>
+#include <io.h>
+
+#define GENI_STATUS_REG			0x40
+#define GENI_STATUS_REG_CMD_ACTIVE	BIT(0)
+#define GENI_TX_FIFO_REG		0x700
+#define GENI_TX_TRANS_LEN_REG		0x270
+#define GENI_M_CMD0_REG			0x600
+
+#define GENI_M_CMD_TX			(0x8000000)
+
+static void qcom_geni_uart_putc(struct serial_chip *chip, int ch)
+{
+	struct qcom_geni_uart_data *pd =
+		container_of(chip, struct qcom_geni_uart_data, chip);
+	vaddr_t base = io_pa_or_va(&pd->base, GENI_UART_REG_SIZE);
+	uint64_t timer = timeout_init_us(1000 * 1000);
+
+	while (io_read32(base + GENI_STATUS_REG) & GENI_STATUS_REG_CMD_ACTIVE) {
+		if (timeout_elapsed(timer))
+			break;
+	}
+	io_write32(base + GENI_TX_TRANS_LEN_REG, 1);
+	io_write32(base + GENI_M_CMD0_REG, GENI_M_CMD_TX);
+	io_write32(base + GENI_TX_FIFO_REG, ch);
+}
+
+static const struct serial_ops qcom_geni_uart_ops = {
+	.putc = qcom_geni_uart_putc,
+};
+DECLARE_KEEP_PAGER(qcom_geni_uart_ops);
+
+void qcom_geni_uart_init(struct qcom_geni_uart_data *pd, paddr_t base)
+{
+	pd->base.pa = base;
+	pd->chip.ops = &qcom_geni_uart_ops;
+
+	/*
+	 * Do nothing, debug uart is shared with normal world, everything
+	 * for debug uart initialization is done in the bootloader.
+	 */
+}

--- a/core/drivers/sub.mk
+++ b/core/drivers/sub.mk
@@ -11,6 +11,7 @@ srcs-$(CFG_PL022) += pl022_spi.c
 srcs-$(CFG_SP805_WDT) += sp805_wdt.c
 srcs-$(CFG_8250_UART) += serial8250_uart.c
 srcs-$(CFG_16550_UART) += ns16550.c
+srcs-$(CFG_QCOM_GENI_UART) += qcom_geni_uart.c
 srcs-$(CFG_IMX_SNVS) += imx_snvs.c
 srcs-$(CFG_IMX_UART) += imx_uart.c
 srcs-$(CFG_IMX_I2C) += imx_i2c.c

--- a/core/include/drivers/qcom_geni_uart.h
+++ b/core/include/drivers/qcom_geni_uart.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2024, Linaro Limited
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+#ifndef __DRIVERS_QCOM_GENI_UART_H
+#define __DRIVERS_QCOM_GENI_UART_H
+
+#include <drivers/serial.h>
+#include <types_ext.h>
+
+#define GENI_UART_REG_SIZE 0x4000
+
+struct qcom_geni_uart_data {
+	struct io_pa_va base;
+	struct serial_chip chip;
+};
+
+void qcom_geni_uart_init(struct qcom_geni_uart_data *pd, paddr_t base);
+
+#endif /* __DRIVERS_QCOM_GENI_UART_H */


### PR DESCRIPTION
Introduce initial Qualcomm platform support for the Kodiak which is the SoC codename also known by product names SC7280/QCM6490 in upstream.