### PR TITLE
drivers: qcom: rpmh: Rename RSC_DRV_TZ to RSC_DRV_SECURE

### DIFF
--- a/core/drivers/qcom/qfprom/qfprom_target.c
+++ b/core/drivers/qcom/qfprom/qfprom_target.c
@@ -70,7 +70,7 @@ TEE_Result qfprom_enable_voltage(void)
 	uint32_t req_id;
 
 	if (!rpmh_handle) {
-		rpmh_handle = rpmh_create_handle(RSC_DRV_TZ, "qfprom");
+		rpmh_handle = rpmh_create_handle(RSC_DRV_SECURE, "qfprom");
 		if (!rpmh_handle) {
 			EMSG("RPMH client creation failed");
 			return TEE_ERROR_GENERIC;

--- a/core/drivers/qcom/rpmh/rpmh_client.c
+++ b/core/drivers/qcom/rpmh/rpmh_client.c
@@ -365,18 +365,7 @@ void rpmh_barrier_single(struct rpmh_client *handle, uint32_t req_id)
 
 bool rpmh_is_drv_id_valid(enum rscsw_drv_mapping drv_id)
 {
-	switch (drv_id) {
-	case RSC_DRV_TZ:
-	case RSC_DRV_CPUCP:
-	case RSC_DRV_HLOS:
-	case RSC_DRV_HYP:
-		return true;
-	default:
-		if (drv_id >= RSC_DRV_VIRTUAL_DRVS &&
-		    drv_id <= RSC_DRV_VIRTUAL_MAX)
-			return true;
-		return false;
-	}
+	return (drv_id == RSC_DRV_SECURE);
 }
 
 early_init(rpmh_client_init);

--- a/core/drivers/qcom/rpmh/rpmh_drv_config.c
+++ b/core/drivers/qcom/rpmh/rpmh_drv_config.c
@@ -23,8 +23,8 @@ static const struct drv_config_data optee_config_data = {
 
 	.drvs = (struct drv_config[]) {
 		{
-			.drv_id = RSC_DRV_TZ,
-			.hw_drv = RSC_DRV_TZ,
+			.drv_id = RSC_DRV_SECURE,
+			.hw_drv = RSC_DRV_SECURE,
 			.wake_set_latency = 0x7080,
 			.tcs_offset = 0,
 			.tcs = RPMH_TCS_ACTIVE + RPMH_TCS_SLEEP + RPMH_TCS_WAKE,

--- a/core/drivers/qcom/rpmh/rpmh_hal.c
+++ b/core/drivers/qcom/rpmh/rpmh_hal.c
@@ -244,7 +244,7 @@ enum hal_status hal_rpmh_update_epcb_timeout(enum rscsw_drv_mapping drv_id,
 	vaddr_t base;
 	uint32_t val;
 
-	if (drv_id != RSC_DRV_TZ)
+	if (drv_id != RSC_DRV_SECURE)
 		return HAL_STATUS_INVALID_PARAM;
 
 	base = get_drv_base(drv_id);
@@ -266,7 +266,7 @@ enum hal_status hal_rpmh_toggle_epcb_timeout(enum rscsw_drv_mapping drv_id,
 	vaddr_t base;
 	uint32_t val;
 
-	if (drv_id != RSC_DRV_TZ)
+	if (drv_id != RSC_DRV_SECURE)
 		return HAL_STATUS_INVALID_PARAM;
 
 	base = get_drv_base(drv_id);

--- a/core/include/drivers/qcom/rpmh/rpmh_client.h
+++ b/core/include/drivers/qcom/rpmh/rpmh_client.h
@@ -20,7 +20,7 @@ enum rpmh_set_enum {
 };
 
 enum rscsw_drv_mapping {
-	RSC_DRV_TZ            = 0,
+	RSC_DRV_SECURE        = 0,
 	RSC_DRV_CPUCP         = 1,
 	RSC_DRV_L3            = RSC_DRV_CPUCP,
 	RSC_DRV_HLOS          = 2,


### PR DESCRIPTION
Rename RSC_DRV_TZ to RSC_DRV_SECURE to better reflect its usage in the secure world context. This driver is shared between TF-A for boot time configuration and OP-TEE for runtime services.

Changes:
- Rename RSC_DRV_TZ to RSC_DRV_SECURE in enum rscsw_drv_mapping
- Update all references across RPMH driver, HAL, and QFPROM
- Simplify rpmh_is_drv_id_valid() to check only RSC_DRV_SECURE

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
