### PR TITLE
pta/ta: qcom: pas: verify PIL firmware segment integrity before reset

### DIFF
--- a/core/arch/arm/plat-qcom/hoya/lemans/target.mk
+++ b/core/arch/arm/plat-qcom/hoya/lemans/target.mk
@@ -16,10 +16,11 @@ endif
 CFG_QCOM_PAS_PTA ?= y
 
 ifeq ($(CFG_QCOM_PAS_PTA),y)
-# PAS subsystems map their controller windows at runtime from the reserved VA
-# pool (never released). The six DSP windows total ~146.5 MB; the 60 MB default
-# fits only one, so reserve 256 MB with headroom.
 CFG_RESERVED_VASPACE_SIZE ?= (256 * 1024 * 1024)
 CFG_IN_TREE_EARLY_TAS += qcom_pas/cff7d191-7ca0-4784-af13-48223b9a4fbe
+
+CFG_QCOM_PAS_AUTH ?= y
+
+CFG_PAS_MD_SLOTS ?= 8
 endif
 CFG_QCOM_HWKM ?= y

--- a/core/pta/qcom/pas/pas_auth_core.c
+++ b/core/pta/qcom/pas/pas_auth_core.c
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <elf32.h>
+#include <elf64.h>
+#include <kernel/cache_helpers.h>
+#include <mm/core_mmu.h>
+#include <pas_auth_core.h>
+#include <platform_pas.h>
+#include <string.h>
+#include <string_ext.h>
+#include <tee/tee_cryp_utl.h>
+#include <trace.h>
+#include <utee_defines.h>
+#include <util.h>
+
+#include "pas_subsys.h"
+
+#define MI_PBT_PAGE_MODE_MASK		0x00100000
+#define MI_PBT_PAGE_MODE_SHIFT		20
+#define MI_PBT_ACCESS_TYPE_MASK		0x00E00000
+#define MI_PBT_ACCESS_TYPE_SHIFT	21
+#define MI_PBT_SEGMENT_TYPE_MASK	0x07000000
+#define MI_PBT_SEGMENT_TYPE_SHIFT	24
+
+#define MI_PBT_NON_PAGED_SEGMENT	0x0
+#define MI_PBT_HASH_SEGMENT		0x2
+#define MI_PBT_NOTUSED_SEGMENT		0x3
+#define MI_PBT_SHARED_SEGMENT		0x4
+
+#define MI_PBT_PAGE_MODE(x) \
+	(((x) & MI_PBT_PAGE_MODE_MASK) >> MI_PBT_PAGE_MODE_SHIFT)
+#define MI_PBT_ACCESS_TYPE(x) \
+	(((x) & MI_PBT_ACCESS_TYPE_MASK) >> MI_PBT_ACCESS_TYPE_SHIFT)
+#define MI_PBT_SEGMENT_TYPE(x) \
+	(((x) & MI_PBT_SEGMENT_TYPE_MASK) >> MI_PBT_SEGMENT_TYPE_SHIFT)
+
+struct elf_info {
+	size_t elf_hdr_len;
+	size_t phdr_offset;
+	size_t phdr_entry_len;
+	size_t phdr_count;
+	uint64_t entry;
+	bool is_64;
+};
+
+struct phdr_info {
+	uint64_t paddr;
+	size_t file_len;
+	size_t mem_len;
+	uint32_t type;
+	uint32_t flags;
+};
+
+#define PARSE_EHDR(e_info, ehdr, _is_64) do {				\
+	(e_info)->is_64 = (_is_64);					\
+	(e_info)->elf_hdr_len = (ehdr)->e_ehsize;			\
+	(e_info)->phdr_offset = (ehdr)->e_phoff;			\
+	(e_info)->phdr_entry_len = (ehdr)->e_phentsize;		\
+	(e_info)->phdr_count = (ehdr)->e_phnum;			\
+	(e_info)->entry = (ehdr)->e_entry;			\
+} while (0)
+
+#define PARSE_PHDR(p_info, phdr) do {					\
+	(p_info)->paddr = (phdr)->p_paddr;				\
+	(p_info)->file_len = (phdr)->p_filesz;				\
+	(p_info)->mem_len = (phdr)->p_memsz;				\
+	(p_info)->type = (phdr)->p_type;				\
+	(p_info)->flags = (phdr)->p_flags;				\
+} while (0)
+
+static bool check_range(uint64_t off, uint64_t len, uint64_t total)
+{
+	uint64_t end = 0;
+
+	if (ADD_OVERFLOW(off, len, &end))
+		return false;
+
+	return end <= total;
+}
+
+static bool is_hashed(uint32_t p_type, uint32_t p_flags)
+{
+	if (p_type != PT_LOAD)
+		return false;
+
+	return MI_PBT_PAGE_MODE(p_flags) == MI_PBT_NON_PAGED_SEGMENT &&
+	       MI_PBT_SEGMENT_TYPE(p_flags) != MI_PBT_HASH_SEGMENT &&
+	       MI_PBT_ACCESS_TYPE(p_flags) != MI_PBT_NOTUSED_SEGMENT &&
+	       MI_PBT_ACCESS_TYPE(p_flags) != MI_PBT_SHARED_SEGMENT;
+}
+
+static TEE_Result parse_elf(const uint8_t *fw, size_t fw_size,
+			    struct elf_info *e_info)
+{
+	const unsigned char *ident = fw;
+
+	if (fw_size < EI_NIDENT)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ident[EI_MAG0] != ELFMAG0 || ident[EI_MAG1] != ELFMAG1 ||
+	    ident[EI_MAG2] != ELFMAG2 || ident[EI_MAG3] != ELFMAG3)
+		return TEE_ERROR_BAD_FORMAT;
+
+	switch (ident[EI_CLASS]) {
+	case ELFCLASS64: {
+		const Elf64_Ehdr *ehdr = (const void *)fw;
+
+		if (fw_size < sizeof(*ehdr))
+			return TEE_ERROR_BAD_FORMAT;
+
+		PARSE_EHDR(e_info, ehdr, true);
+		if (e_info->elf_hdr_len < sizeof(*ehdr) ||
+		    e_info->phdr_entry_len < sizeof(Elf64_Phdr))
+			return TEE_ERROR_BAD_FORMAT;
+		break;
+	}
+	case ELFCLASS32: {
+		const Elf32_Ehdr *ehdr = (const void *)fw;
+
+		if (fw_size < sizeof(*ehdr))
+			return TEE_ERROR_BAD_FORMAT;
+
+		PARSE_EHDR(e_info, ehdr, false);
+		if (e_info->elf_hdr_len < sizeof(*ehdr) ||
+		    e_info->phdr_entry_len < sizeof(Elf32_Phdr))
+			return TEE_ERROR_BAD_FORMAT;
+		break;
+	}
+	default:
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	return TEE_SUCCESS;
+}
+
+static void get_phdr(const uint8_t *fw, const struct elf_info *e_info,
+		     size_t idx, struct phdr_info *p_info)
+{
+	const uint8_t *p = fw + e_info->phdr_offset +
+			   idx * e_info->phdr_entry_len;
+
+	if (e_info->is_64) {
+		const Elf64_Phdr *phdr = (const void *)p;
+
+		PARSE_PHDR(p_info, phdr);
+	} else {
+		const Elf32_Phdr *phdr = (const void *)p;
+
+		PARSE_PHDR(p_info, phdr);
+	}
+}
+
+static TEE_Result image_range(const uint8_t *fw, const struct elf_info *e_info,
+			      uint64_t *base, uint64_t *end)
+{
+	uint64_t min_paddr = UINT64_MAX;
+	struct phdr_info p_info = { };
+	uint64_t seg_end = 0;
+	uint64_t max_end = 0;
+	size_t i = 0;
+
+	for (i = 0; i < e_info->phdr_count; i++) {
+		get_phdr(fw, e_info, i, &p_info);
+
+		if (!is_hashed(p_info.type, p_info.flags))
+			continue;
+
+		if (ADD_OVERFLOW(p_info.paddr, p_info.mem_len, &seg_end))
+			return TEE_ERROR_BAD_FORMAT;
+
+		if (p_info.paddr < min_paddr)
+			min_paddr = p_info.paddr;
+		if (seg_end > max_end)
+			max_end = seg_end;
+	}
+
+	if (min_paddr == UINT64_MAX)
+		return TEE_ERROR_BAD_FORMAT;
+
+	*base = ROUNDDOWN(min_paddr, SMALL_PAGE_SIZE);
+	if (ROUNDUP_OVERFLOW(max_end, SMALL_PAGE_SIZE, end))
+		return TEE_ERROR_BAD_FORMAT;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result hash_verify(uint32_t algo, const uint8_t *data,
+			      size_t data_len, const uint8_t *expected,
+			      size_t hash_len)
+{
+	uint8_t digest[PAS_AUTH_CORE_MAX_HASH_SIZE] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (hash_len > sizeof(digest))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = tee_hash_createdigest(algo, data, data_len, digest, hash_len);
+	if (res)
+		return res;
+
+	if (consttime_memcmp(digest, expected, hash_len))
+		res = TEE_ERROR_SECURITY;
+	else
+		res = TEE_SUCCESS;
+
+	memzero_explicit(digest, sizeof(digest));
+
+	return res;
+}
+
+static TEE_Result verify_elf_header(const struct pas_auth_core_ctx *ctx,
+				    const struct elf_info *e_info)
+{
+	size_t hdr_len = 0;
+
+	if (MUL_OVERFLOW(e_info->phdr_entry_len, e_info->phdr_count, &hdr_len))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ADD_OVERFLOW(hdr_len, e_info->elf_hdr_len, &hdr_len))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (hdr_len > ctx->metadata_len)
+		return TEE_ERROR_BAD_FORMAT;
+
+	return hash_verify(ctx->hash_algo, ctx->metadata, hdr_len,
+			   ctx->hash_table, ctx->hash_len);
+}
+
+TEE_Result pas_auth_core_verify_segments(const struct pas_auth_core_ctx *ctx)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	const uint8_t *expected = NULL;
+	struct phdr_info p_info = { };
+	struct elf_info e_info = { };
+	size_t phdr_table_len = 0;
+	uint64_t image_end = 0;
+	uint64_t offset = 0;
+	size_t verified = 0;
+	uint64_t base = 0;
+	size_t i = 0;
+
+	if (!ctx || !ctx->hash_table || !ctx->fw || !ctx->metadata)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!ctx->hash_len || ctx->hash_len > PAS_AUTH_CORE_MAX_HASH_SIZE)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = parse_elf(ctx->metadata, ctx->metadata_len, &e_info);
+	if (res)
+		return res;
+
+	if (MUL_OVERFLOW(e_info.phdr_entry_len, e_info.phdr_count,
+			 &phdr_table_len) ||
+	    !check_range(e_info.phdr_offset, phdr_table_len, ctx->metadata_len))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ctx->num_entries != e_info.phdr_count)
+		return TEE_ERROR_SECURITY;
+
+	res = verify_elf_header(ctx, &e_info);
+	if (res) {
+		EMSG("PAS auth: ELF header hash mismatch");
+		return res;
+	}
+
+	res = image_range(ctx->metadata, &e_info, &base, &image_end);
+	if (res)
+		return res;
+
+	if (e_info.entry < base || e_info.entry > image_end) {
+		EMSG("PAS auth: entry point outside image");
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	if (image_end - base > ctx->fw_size) {
+		EMSG("PAS auth: image larger than carveout");
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	for (i = 0; i < e_info.phdr_count; i++) {
+		get_phdr(ctx->metadata, &e_info, i, &p_info);
+
+		if (!is_hashed(p_info.type, p_info.flags) || !p_info.file_len)
+			continue;
+
+		if (p_info.paddr < base)
+			return TEE_ERROR_BAD_FORMAT;
+		offset = p_info.paddr - base;
+
+		if (!check_range(offset, p_info.file_len, ctx->fw_size))
+			return TEE_ERROR_BAD_FORMAT;
+
+		if (p_info.mem_len < p_info.file_len)
+			return TEE_ERROR_BAD_FORMAT;
+		if (!check_range(offset, p_info.mem_len, ctx->fw_size))
+			return TEE_ERROR_BAD_FORMAT;
+		if (p_info.mem_len > p_info.file_len) {
+			void *zi = ctx->fw + offset + p_info.file_len;
+			size_t zi_len = p_info.mem_len - p_info.file_len;
+
+			memset(zi, 0, zi_len);
+
+			/*
+			 * The REE maps this carveout uncached and the DSP
+			 * fetches it outside the CPU's coherency domain, so the
+			 * zeros must reach DDR before reset release.
+			 */
+			dcache_cleaninv_range(zi, zi_len);
+		}
+
+		expected = ctx->hash_table + i * ctx->hash_len;
+
+		res = hash_verify(ctx->hash_algo, ctx->fw + offset,
+				  p_info.file_len, expected, ctx->hash_len);
+		if (res) {
+			EMSG("PAS auth: segment %zu hash mismatch", i);
+			return res;
+		}
+
+		verified++;
+	}
+
+	if (!verified) {
+		EMSG("PAS auth: no loadable segments were hashed");
+		return TEE_ERROR_SECURITY;
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_platform_verify_image(uint32_t pas_id,
+				     const struct pas_fw_region *fw,
+				     const struct pas_metadata *metadata,
+				     const struct pas_hash_table *hash)
+{
+	struct qcom_pas_subsys *subsys = pas_lookup(pas_id);
+	struct pas_auth_core_ctx ctx = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct qcom_pas_data *data = NULL;
+	uint32_t fw_size = 0;
+	void *fw_va = NULL;
+
+	if (!subsys)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	if (!metadata->data || !metadata->size || !hash->table ||
+	    !hash->len || !fw->size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!hash->entry_size || hash->len % hash->entry_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	data = &subsys->data;
+
+	if (!data->fw_base || !data->fw_size) {
+		EMSG("PAS auth: no MEM_SETUP for pas_id=%#"PRIx32, pas_id);
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	if (fw->base != data->fw_base) {
+		EMSG("PAS auth: base %#"PRIxPA" != MEM_SETUP %#"PRIxPA,
+		     fw->base, data->fw_base);
+		return TEE_ERROR_SECURITY;
+	}
+	fw_size = data->fw_size;
+
+	fw_va = core_mmu_add_mapping(MEM_AREA_RAM_NSEC, fw->base, fw_size);
+	if (!fw_va) {
+		EMSG("PAS auth: can't map carveout %#"PRIxPA"/%#"PRIx32,
+		     fw->base, fw_size);
+		return TEE_ERROR_GENERIC;
+	}
+
+	switch (hash->entry_size) {
+	case TEE_SHA256_HASH_SIZE:
+		ctx.hash_algo = TEE_ALG_SHA256;
+		break;
+	case TEE_SHA384_HASH_SIZE:
+		ctx.hash_algo = TEE_ALG_SHA384;
+		break;
+	default:
+		res = TEE_ERROR_NOT_SUPPORTED;
+		goto out;
+	}
+
+	ctx.hash_len = hash->entry_size;
+	ctx.hash_table = hash->table;
+	ctx.num_entries = hash->len / hash->entry_size;
+	ctx.metadata = metadata->data;
+	ctx.metadata_len = metadata->size;
+	ctx.fw = fw_va;
+	ctx.fw_size = fw_size;
+
+	res = pas_auth_core_verify_segments(&ctx);
+out:
+	if (core_mmu_remove_mapping(MEM_AREA_RAM_NSEC, fw_va, fw_size))
+		EMSG("PAS auth: failed to unmap carveout");
+
+	return res;
+}

--- a/core/pta/qcom/pas/pas_auth_core.h
+++ b/core/pta/qcom/pas/pas_auth_core.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_AUTH_CORE_H
+#define __PAS_AUTH_CORE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+#define PAS_AUTH_CORE_MAX_HASH_SIZE	48U
+
+struct pas_auth_core_ctx {
+	uint32_t hash_algo;
+	size_t hash_len;
+	const uint8_t *hash_table;
+	uint32_t num_entries;
+	const uint8_t *metadata;
+	size_t metadata_len;
+	uint8_t *fw;
+	size_t fw_size;
+};
+
+TEE_Result pas_auth_core_verify_segments(const struct pas_auth_core_ctx *ctx);
+
+#endif /* __PAS_AUTH_CORE_H */

--- a/core/pta/qcom/pas/pas_core.c
+++ b/core/pta/qcom/pas/pas_core.c
@@ -4,7 +4,6 @@
  */
 
 #include <drivers/clk_qcom.h>
-#include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <platform_pas.h>
 #include <trace.h>
@@ -12,7 +11,7 @@
 
 #include "pas_subsys.h"
 
-static struct qcom_pas_subsys *pas_lookup(uint32_t pas_id)
+struct qcom_pas_subsys *pas_lookup(uint32_t pas_id)
 {
 	struct qcom_pas_subsys *subsys = NULL;
 	size_t count = 0;
@@ -98,8 +97,8 @@ TEE_Result pas_platform_set_remote_state(uint32_t pas_id, uint32_t state)
 TEE_Result pas_platform_auth_and_reset(uint32_t pas_id)
 {
 	struct qcom_pas_subsys *subsys = pas_lookup(pas_id);
-	struct qcom_pas_data *data = NULL;
 	TEE_Result res = TEE_ERROR_GENERIC;
+	struct qcom_pas_data *data = NULL;
 
 	if (!subsys)
 		return TEE_ERROR_NOT_SUPPORTED;
@@ -141,9 +140,16 @@ TEE_Result pas_platform_auth_and_reset(uint32_t pas_id)
 TEE_Result pas_platform_shutdown(uint32_t pas_id)
 {
 	struct qcom_pas_subsys *subsys = pas_lookup(pas_id);
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (!subsys || !subsys->ops->fw_shutdown)
 		return TEE_ERROR_NOT_SUPPORTED;
 
-	return subsys->ops->fw_shutdown(&subsys->data);
+	res = subsys->ops->fw_shutdown(&subsys->data);
+	if (!res) {
+		subsys->data.fw_base = 0;
+		subsys->data.fw_size = 0;
+	}
+
+	return res;
 }

--- a/core/pta/qcom/pas/platform/pas_subsys.h
+++ b/core/pta/qcom/pas/platform/pas_subsys.h
@@ -77,4 +77,6 @@ struct qcom_pas_subsys {
  */
 struct qcom_pas_subsys *qcom_pas_platform_subsys(size_t *count);
 
+struct qcom_pas_subsys *pas_lookup(uint32_t pas_id);
+
 #endif /* PAS_SUBSYS_H */

--- a/core/pta/qcom/pas/platform/platform_pas.h
+++ b/core/pta/qcom/pas/platform/platform_pas.h
@@ -7,6 +7,8 @@
 #define PLATFORM_PAS_H
 
 #include <resource_table.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
 
 TEE_Result pas_platform_mem_setup(uint32_t pas_id, uint32_t fw_size,
 				  uint32_t fw_base_low, uint32_t fw_base_high);
@@ -19,5 +21,37 @@ TEE_Result pas_platform_is_supported(uint32_t pas_id);
 TEE_Result pas_platform_capabilities(uint32_t pas_id);
 TEE_Result pas_platform_init_image(uint32_t pas_id);
 TEE_Result pas_platform_shutdown(uint32_t pas_id);
+
+struct pas_fw_region {
+	paddr_t base;
+	uint32_t size;
+};
+
+struct pas_metadata {
+	const uint8_t *data;
+	size_t size;
+};
+
+struct pas_hash_table {
+	const uint8_t *table;
+	size_t len;
+	uint32_t entry_size;
+};
+
+#ifdef CFG_QCOM_PAS_AUTH
+TEE_Result pas_platform_verify_image(uint32_t pas_id,
+				     const struct pas_fw_region *fw,
+				     const struct pas_metadata *metadata,
+				     const struct pas_hash_table *hash);
+#else
+static inline TEE_Result
+pas_platform_verify_image(uint32_t pas_id __unused,
+			  const struct pas_fw_region *fw __unused,
+			  const struct pas_metadata *metadata __unused,
+			  const struct pas_hash_table *hash __unused)
+{
+	return TEE_SUCCESS;
+}
+#endif /* CFG_QCOM_PAS_AUTH */
 
 #endif

--- a/core/pta/qcom/pas/pta_qcom_pas.c
+++ b/core/pta/qcom/pas/pta_qcom_pas.c
@@ -3,13 +3,12 @@
  * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
-#include <initcall.h>
 #include <kernel/pseudo_ta.h>
-#include <kernel/user_ta.h>
-#include <platform_config.h>
+#include <kernel/ts_manager.h>
 #include <platform_pas.h>
 #include <pta_qcom_pas.h>
 #include <string.h>
+#include <util.h>
 
 #define PTA_NAME	"pta.qcom.pas"
 
@@ -45,7 +44,7 @@ static TEE_Result qcom_pas_capabilities(uint32_t pt,
 
 	/* Capabilities flags reserved for future use */
 	params[1].value.a = 0;
-	return pas_platform_capabilities(params[1].value.a);
+	return pas_platform_capabilities(params[0].value.a);
 }
 
 static TEE_Result qcom_pas_init_image(uint32_t pt,

--- a/core/pta/qcom/pas/pta_qcom_pas.c
+++ b/core/pta/qcom/pas/pta_qcom_pas.c
@@ -95,8 +95,7 @@ static TEE_Result qcom_pas_get_resource_table(uint32_t pt,
 }
 
 static TEE_Result
-qcom_pas_set_remote_state(uint32_t pt,
-			  TEE_Param params[TEE_NUM_PARAMS]__maybe_unused)
+qcom_pas_set_remote_state(uint32_t pt, TEE_Param params[TEE_NUM_PARAMS])
 {
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 						TEE_PARAM_TYPE_NONE,
@@ -127,8 +126,7 @@ static TEE_Result qcom_pas_auth_and_reset(uint32_t pt,
 }
 
 static TEE_Result
-qcom_pas_shutdown(uint32_t pt,
-		  TEE_Param params[TEE_NUM_PARAMS] __maybe_unused)
+qcom_pas_shutdown(uint32_t pt, TEE_Param params[TEE_NUM_PARAMS])
 {
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 						TEE_PARAM_TYPE_NONE,
@@ -140,6 +138,41 @@ qcom_pas_shutdown(uint32_t pt,
 	DMSG("invoked with pas_id: %d", params[0].value.a);
 
 	return pas_platform_shutdown(params[0].value.a);
+}
+
+static TEE_Result
+qcom_pas_verify_image(uint32_t pt, TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						TEE_PARAM_TYPE_VALUE_INPUT,
+						TEE_PARAM_TYPE_MEMREF_INPUT,
+						TEE_PARAM_TYPE_VALUE_INPUT);
+	struct pas_metadata metadata = { };
+	struct pas_hash_table hash = { };
+	struct pas_fw_region fw = { };
+	const uint8_t *buf = NULL;
+
+	if (pt != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!params[2].memref.buffer || !params[2].memref.size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	metadata.size = params[3].value.b;
+	if (!metadata.size || metadata.size >= params[2].memref.size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	buf = params[2].memref.buffer;
+	metadata.data = buf;
+	hash.table = buf + metadata.size;
+	hash.len = params[2].memref.size - metadata.size;
+	hash.entry_size = params[3].value.a;
+
+	fw.base = reg_pair_to_64(params[1].value.b, params[1].value.a);
+	fw.size = params[0].value.b;
+
+	return pas_platform_verify_image(params[0].value.a, &fw, &metadata,
+					 &hash);
 }
 
 static TEE_Result pta_qcom_pas_invoke_command(void *session __unused,
@@ -164,6 +197,8 @@ static TEE_Result pta_qcom_pas_invoke_command(void *session __unused,
 		return qcom_pas_set_remote_state(param_types, params);
 	case PTA_QCOM_PAS_SHUTDOWN:
 		return qcom_pas_shutdown(param_types, params);
+	case PTA_QCOM_PAS_VERIFY_IMAGE:
+		return qcom_pas_verify_image(param_types, params);
 	default:
 		return TEE_ERROR_NOT_IMPLEMENTED;
 	}

--- a/core/pta/qcom/pas/sub.mk
+++ b/core/pta/qcom/pas/sub.mk
@@ -1,5 +1,6 @@
 srcs-y += pta_qcom_pas.c
 srcs-y += pas_core.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth_core.c
 incdirs-y += .
 incdirs-y += platform/
 subdirs-y += platform/$(PLATFORM_FLAVOR)

--- a/core/pta/qcom/pas/sub.mk
+++ b/core/pta/qcom/pas/sub.mk
@@ -4,3 +4,6 @@ srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth_core.c
 incdirs-y += .
 incdirs-y += platform/
 subdirs-y += platform/$(PLATFORM_FLAVOR)
+
+# PIL PAS authentication metadata slots, defaults to 1.
+CFG_PAS_MD_SLOTS ?= 1

--- a/lib/libutee/include/pta_qcom_pas.h
+++ b/lib/libutee/include/pta_qcom_pas.h
@@ -84,4 +84,23 @@
  */
 #define PTA_QCOM_PAS_SHUTDOWN			8
 
-#endif /* __PTA_QCOM_REMOTEPROC_H */
+/*
+ * PAS firmware image integrity verification.
+ *
+ * The caller is responsible for ensuring the hash table is trusted.
+ *
+ * [in]  params[0].value.a:	Unique 32bit remote processor identifier
+ * [in]  params[0].value.b:	Firmware size
+ * [in]  params[1].value.a:	32bit LSB firmware memory address
+ * [in]  params[1].value.b:	32bit MSB firmware memory address
+ * [in]  params[2].memref:	Packed [metadata | hash_table] buffer: the
+ *				INIT_IMAGE metadata blob (ELF header + phdrs)
+ *				followed immediately by the per-segment
+ *				hash table (one digest per phdr)
+ * [in]  params[3].value.a:	Digest size in bytes (32=SHA-256, 48=SHA-384)
+ * [in]  params[3].value.b:	Metadata size, i.e. offset of hash_table
+ *				within params[2].memref
+ */
+#define PTA_QCOM_PAS_VERIFY_IMAGE		9
+
+#endif /* __PTA_QCOM_PAS_H */

--- a/ta/qcom_pas/include/pas_auth.h
+++ b/ta/qcom_pas/include/pas_auth.h
@@ -1,0 +1,58 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_AUTH_H
+#define __PAS_AUTH_H
+
+#include <qcom_pas_priv.h>
+#include <tee_internal_api.h>
+
+#ifdef CFG_QCOM_PAS_AUTH
+TEE_Result pas_auth_save_metadata(struct qcom_pas_session *s, uint32_t pt,
+				  TEE_Param params[TEE_NUM_PARAMS]);
+
+TEE_Result pas_auth_authenticate(struct qcom_pas_session *s, uint32_t pas_id);
+
+TEE_Result pas_auth_verify_reset(struct qcom_pas_session *s,
+				 TEE_TASessionHandle pta_session,
+				 uint32_t pas_id,
+				 TEE_Param params[TEE_NUM_PARAMS]);
+
+TEE_Result pas_auth_release_metadata(struct qcom_pas_session *s,
+				     uint32_t pas_id);
+#else
+static inline TEE_Result
+pas_auth_save_metadata(struct qcom_pas_session *s __unused,
+		       uint32_t pt __unused,
+		       TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	return TEE_SUCCESS;
+}
+
+static inline TEE_Result
+pas_auth_authenticate(struct qcom_pas_session *s __unused,
+		      uint32_t pas_id __unused)
+{
+	return TEE_SUCCESS;
+}
+
+static inline TEE_Result
+pas_auth_verify_reset(struct qcom_pas_session *s __unused,
+		      TEE_TASessionHandle pta_session __unused,
+		      uint32_t pas_id __unused,
+		      TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	return TEE_SUCCESS;
+}
+
+static inline TEE_Result
+pas_auth_release_metadata(struct qcom_pas_session *s __unused,
+			  uint32_t pas_id __unused)
+{
+	return TEE_SUCCESS;
+}
+#endif /* CFG_QCOM_PAS_AUTH */
+
+#endif /* __PAS_AUTH_H */

--- a/ta/qcom_pas/include/pas_mbn_parser.h
+++ b/ta/qcom_pas/include/pas_mbn_parser.h
@@ -1,0 +1,60 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_MBN_PARSER_H
+#define __PAS_MBN_PARSER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * On-wire layout of the INIT_IMAGE metadata blob:
+ *   [ phdrs[0].p_filesz bytes ]  ELF header + program-header table
+ *   [ hash-segment bytes      ]  verbatim MBN hash-segment phdr content
+ *
+ * MBN hash segment, v6 (48-byte header):
+ *   [header][qti meta][oem meta][hash table]
+ *   [qti sig][qti certs][oem sig][oem certs]
+ *
+ * Hash table: one digest per ELF program header; entry 0 = digest of the ELF
+ * header plus program-header table, entry i = digest of the segment at phdr i.
+ */
+
+#define PAS_MBN_VERSION_6	6
+
+struct pas_mbn {
+	uint32_t version;
+
+	const uint8_t *hash_table;
+	size_t hash_table_size;
+	uint32_t num_entries;
+	uint32_t hash_len;
+
+	const uint8_t *signed_region;
+	size_t signed_region_size;
+
+	const uint8_t *oem_meta;
+	size_t oem_meta_size;
+	const uint8_t *oem_sig;
+	size_t oem_sig_size;
+	const uint8_t *oem_certs;
+	size_t oem_certs_size;
+
+	const uint8_t *qti_meta;
+	size_t qti_meta_size;
+	const uint8_t *qti_sig;
+	size_t qti_sig_size;
+	const uint8_t *qti_certs;
+	size_t qti_certs_size;
+
+	bool uie_encrypted;
+};
+
+TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
+			 uint32_t hash_len, struct pas_mbn *out);
+
+#endif /* __PAS_MBN_PARSER_H */

--- a/ta/qcom_pas/include/pas_mbn_parser_priv.h
+++ b/ta/qcom_pas/include/pas_mbn_parser_priv.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_MBN_PARSER_PRIV_H
+#define __PAS_MBN_PARSER_PRIV_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/* MBN header field offsets (bytes from hash-segment start) */
+#define MBN_OFF_VERSION		0x04
+#define MBN_OFF_QC_SIG_SIZE	0x08
+#define MBN_OFF_QC_CERT_SIZE	0x0c
+#define MBN_OFF_CODE_SIZE	0x14
+#define MBN_OFF_OEM_SIG_SIZE	0x1c
+#define MBN_OFF_OEM_CERT_SIZE	0x24
+#define MBN_OFF_QC_META_SIZE	0x28
+#define MBN_OFF_OEM_META_SIZE	0x2c
+
+#define MBN_HDR_SIZE_V6		0x30
+
+/* Read a little-endian uint32_t from @p. */
+uint32_t pas_mbn_read_u32(const uint8_t *p);
+
+TEE_Result pas_mbn_locate(const uint8_t *md, size_t md_size,
+			  const uint8_t **seg, size_t *seg_size);
+
+TEE_Result pas_mbn_reserve_region(const uint8_t *segment, size_t segment_size,
+				  size_t *offset, size_t len,
+				  const uint8_t **region, size_t *region_len);
+
+#endif /* __PAS_MBN_PARSER_PRIV_H */

--- a/ta/qcom_pas/include/pas_meta.h
+++ b/ta/qcom_pas/include/pas_meta.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_META_H
+#define __PAS_META_H
+
+#include <pas_mbn_parser.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+TEE_Result pas_meta_get_version(const uint8_t *meta_data,
+				size_t meta_data_size, uint32_t *version);
+
+TEE_Result pas_meta_segment_hash_len(const uint8_t *meta_data,
+				     size_t meta_data_size,
+				     uint32_t *hash_len);
+
+#endif /* __PAS_META_H */

--- a/ta/qcom_pas/include/qcom_pas_priv.h
+++ b/ta/qcom_pas/include/qcom_pas_priv.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __QCOM_PAS_PRIV_H
+#define __QCOM_PAS_PRIV_H
+
+#include <pas_mbn_parser.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define PAS_MD_SLOTS		CFG_PAS_MD_SLOTS
+
+struct pas_md_slot {
+	void *meta_data;
+	size_t meta_data_size;
+	uint32_t pas_id;
+	bool in_use;
+	struct pas_mbn mbn;
+	bool ready;
+};
+
+struct qcom_pas_session {
+	struct pas_md_slot slots[PAS_MD_SLOTS];
+};
+
+#endif /* __QCOM_PAS_PRIV_H */

--- a/ta/qcom_pas/src/pas_auth.c
+++ b/ta/qcom_pas/src/pas_auth.c
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <pas_auth.h>
+#include <pas_mbn_parser.h>
+#include <pas_meta.h>
+#include <pta_qcom_pas.h>
+#include <qcom_pas_priv.h>
+#include <string.h>
+#include <tee_internal_api.h>
+#include <utee_defines.h>
+
+static struct pas_md_slot *get_meta_data_slot(struct qcom_pas_session *s,
+					      uint32_t pas_id)
+{
+	size_t i = 0;
+
+	for (i = 0; i < PAS_MD_SLOTS; i++) {
+		if (s->slots[i].in_use && s->slots[i].pas_id == pas_id)
+			return &s->slots[i];
+	}
+
+	return NULL;
+}
+
+TEE_Result pas_auth_save_metadata(struct qcom_pas_session *s, uint32_t pt,
+				  TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						TEE_PARAM_TYPE_MEMREF_INPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	struct pas_md_slot *slot = NULL;
+	void *meta_data_copy = NULL;
+	uint32_t pas_id = 0;
+	size_t size = 0;
+	size_t i = 0;
+
+	if (pt != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	size = params[1].memref.size;
+	if (size && !params[1].memref.buffer)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	pas_id = params[0].value.a;
+
+	slot = get_meta_data_slot(s, pas_id);
+	if (!slot) {
+		for (i = 0; i < PAS_MD_SLOTS; i++) {
+			if (!s->slots[i].in_use) {
+				slot = &s->slots[i];
+				goto found;
+			}
+		}
+		EMSG("PAS auth: no free md slot (pas_id=%#"PRIx32")", pas_id);
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+found:
+	if (size) {
+		meta_data_copy = TEE_Malloc(size, TEE_MALLOC_FILL_ZERO);
+		if (!meta_data_copy)
+			return TEE_ERROR_OUT_OF_MEMORY;
+		memcpy(meta_data_copy, params[1].memref.buffer, size);
+	}
+
+	TEE_Free(slot->meta_data);
+	slot->meta_data = meta_data_copy;
+	slot->meta_data_size = size;
+	slot->pas_id = pas_id;
+	slot->in_use = true;
+	slot->ready = false;
+	memset(&slot->mbn, 0, sizeof(slot->mbn));
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_auth_authenticate(struct qcom_pas_session *s, uint32_t pas_id)
+{
+	struct pas_md_slot *slot = get_meta_data_slot(s, pas_id);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t hash_len = 0;
+
+	if (!slot) {
+		EMSG("PAS auth: no metadata for pas_id=%#"PRIx32
+		     " (call INIT_IMAGE first)", pas_id);
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	res = pas_meta_segment_hash_len(slot->meta_data, slot->meta_data_size,
+					&hash_len);
+	if (res) {
+		EMSG("PAS auth: cannot pick hash size: %#"PRIx32, res);
+		return res;
+	}
+
+	res = pas_mbn_parse(slot->meta_data, slot->meta_data_size, hash_len,
+			    &slot->mbn);
+	if (res) {
+		EMSG("PAS auth: MBN parse failed: %#"PRIx32, res);
+		return res;
+	}
+
+	slot->ready = true;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_auth_verify_reset(struct qcom_pas_session *s,
+				 TEE_TASessionHandle pta_session,
+				 uint32_t pas_id,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	struct pas_md_slot *slot = get_meta_data_slot(s, pas_id);
+	TEE_Param vp[TEE_NUM_PARAMS] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t buffer_size = 0;
+	uint8_t *buffer = NULL;
+	uint32_t pt = 0;
+
+	if (!slot || !slot->ready) {
+		EMSG("PAS auth: pas_id=%#"PRIx32
+		     " is not ready (call INIT_IMAGE first)", pas_id);
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	if (ADD_OVERFLOW(slot->meta_data_size, slot->mbn.hash_table_size,
+			 &buffer_size))
+		return TEE_ERROR_OVERFLOW;
+
+	buffer = TEE_Malloc(buffer_size, TEE_MALLOC_FILL_ZERO);
+	if (!buffer)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	TEE_MemMove(buffer, slot->meta_data, slot->meta_data_size);
+	TEE_MemMove(buffer + slot->meta_data_size, slot->mbn.hash_table,
+		    slot->mbn.hash_table_size);
+
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+			     TEE_PARAM_TYPE_VALUE_INPUT,
+			     TEE_PARAM_TYPE_MEMREF_INPUT,
+			     TEE_PARAM_TYPE_VALUE_INPUT);
+
+	vp[0].value.a = params[0].value.a;
+	vp[0].value.b = params[0].value.b;
+	vp[1].value.a = params[1].value.a;
+	vp[1].value.b = params[1].value.b;
+	vp[2].memref.buffer = buffer;
+	vp[2].memref.size = buffer_size;
+	vp[3].value.a = slot->mbn.hash_len;
+	vp[3].value.b = slot->meta_data_size;
+
+	res = TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
+				  PTA_QCOM_PAS_VERIFY_IMAGE, pt, vp, NULL);
+
+	TEE_Free(buffer);
+	return res;
+}
+
+TEE_Result pas_auth_release_metadata(struct qcom_pas_session *s,
+				     uint32_t pas_id)
+{
+	struct pas_md_slot *slot = get_meta_data_slot(s, pas_id);
+
+	if (!slot)
+		return TEE_SUCCESS;
+
+	TEE_Free(slot->meta_data);
+	slot->meta_data = NULL;
+	slot->meta_data_size = 0;
+	slot->ready = false;
+	memset(&slot->mbn, 0, sizeof(slot->mbn));
+
+	return TEE_SUCCESS;
+}

--- a/ta/qcom_pas/src/pas_mbn_parser.c
+++ b/ta/qcom_pas/src/pas_mbn_parser.c
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <elf32.h>
+#include <elf64.h>
+#include <pas_mbn_parser.h>
+#include <pas_mbn_parser_priv.h>
+#include <string.h>
+#include <tee_internal_api.h>
+#include <util.h>
+
+/* Header magic of the optional UIE encryption block in the hash segment. */
+#define UIE_ENC_PARAM_MAGIC	0x514D5349	/* "ISMQ" */
+
+/* Segment type lives in bits 24:26 of p_flags; 0x2 marks the hash segment. */
+#define MBN_PT_FLAG_TYPE_MASK		0x07000000U
+#define MBN_PT_FLAG_HASH_TYPE_MASK	0x02000000U
+
+uint32_t pas_mbn_read_u32(const uint8_t *p)
+{
+	uint32_t v = 0;
+
+	memcpy(&v, p, sizeof(v));
+
+	return v;
+}
+
+TEE_Result pas_mbn_locate(const uint8_t *md, size_t md_size,
+			  const uint8_t **seg, size_t *seg_size)
+{
+	const unsigned char *ident = md;
+	size_t phdr_entry_len = 0;
+	size_t phdr_entry_min = 0;
+	size_t phdr_table_end = 0;
+	size_t phdr_offset = 0;
+	size_t phdr_count = 0;
+	uint32_t hash_flags = 0;
+	size_t hash_seg_len = 0;
+	size_t elf_hdr_len = 0;
+	size_t hash_seg_offset = 0;
+	size_t hash_seg_end = 0;
+	bool is_64 = false;
+	bool found = false;
+	size_t i = 0;
+
+	if (md_size < EI_NIDENT)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ident[EI_MAG0] != ELFMAG0 || ident[EI_MAG1] != ELFMAG1 ||
+	    ident[EI_MAG2] != ELFMAG2 || ident[EI_MAG3] != ELFMAG3)
+		return TEE_ERROR_BAD_FORMAT;
+
+	switch (ident[EI_CLASS]) {
+	case ELFCLASS64:
+		is_64 = true;
+		elf_hdr_len = sizeof(Elf64_Ehdr);
+		phdr_entry_min = sizeof(Elf64_Phdr);
+		break;
+	case ELFCLASS32:
+		is_64 = false;
+		elf_hdr_len = sizeof(Elf32_Ehdr);
+		phdr_entry_min = sizeof(Elf32_Phdr);
+		break;
+	default:
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	if (md_size < elf_hdr_len)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (is_64) {
+		const Elf64_Ehdr *ehdr = (const void *)md;
+
+		phdr_offset = ehdr->e_phoff;
+		phdr_entry_len = ehdr->e_phentsize;
+		phdr_count = ehdr->e_phnum;
+	} else {
+		const Elf32_Ehdr *ehdr = (const void *)md;
+
+		phdr_offset = ehdr->e_phoff;
+		phdr_entry_len = ehdr->e_phentsize;
+		phdr_count = ehdr->e_phnum;
+	}
+
+	if (phdr_count < 2 || phdr_offset != elf_hdr_len ||
+	    phdr_entry_len != phdr_entry_min)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (MUL_OVERFLOW(phdr_entry_len, phdr_count, &phdr_table_end) ||
+	    ADD_OVERFLOW(phdr_table_end, phdr_offset, &phdr_table_end) ||
+	    phdr_table_end > md_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	for (i = 0; i < phdr_count; i++) {
+		const uint8_t *p = md + phdr_offset + i * phdr_entry_len;
+
+		if (is_64) {
+			const Elf64_Phdr *phdr = (const void *)p;
+
+			hash_flags = phdr->p_flags;
+			hash_seg_len = phdr->p_filesz;
+		} else {
+			const Elf32_Phdr *phdr = (const void *)p;
+
+			hash_flags = phdr->p_flags;
+			hash_seg_len = phdr->p_filesz;
+		}
+
+		if ((hash_flags & MBN_PT_FLAG_TYPE_MASK) ==
+		    MBN_PT_FLAG_HASH_TYPE_MASK) {
+			found = true;
+			break;
+		}
+	}
+	if (!found)
+		return TEE_ERROR_BAD_FORMAT;
+
+	/*
+	 * The hash segment is packed immediately after the ELF header and
+	 * program-header table, so its offset is the ELF header length plus
+	 * the phdr table length. The phdr p_offset refers to the original
+	 * firmware file and must not be used here.
+	 */
+	if (MUL_OVERFLOW(phdr_entry_len, phdr_count, &hash_seg_offset) ||
+	    ADD_OVERFLOW(hash_seg_offset, elf_hdr_len, &hash_seg_offset))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ADD_OVERFLOW(hash_seg_offset, hash_seg_len, &hash_seg_end) ||
+	    hash_seg_end > md_size || !hash_seg_len)
+		return TEE_ERROR_BAD_FORMAT;
+
+	*seg = md + hash_seg_offset;
+	*seg_size = hash_seg_len;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_mbn_reserve_region(const uint8_t *segment, size_t segment_size,
+				  size_t *offset, size_t len,
+				  const uint8_t **region, size_t *region_len)
+{
+	if (!len) {
+		*region = NULL;
+		*region_len = 0;
+		return TEE_SUCCESS;
+	}
+
+	if (len > segment_size || *offset > segment_size - len)
+		return TEE_ERROR_BAD_FORMAT;
+
+	*region = segment + *offset;
+	*region_len = len;
+	*offset += len;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
+			 uint32_t hash_len, struct pas_mbn *out)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t oem_cert_size = 0;
+	uint32_t oem_meta_size = 0;
+	const uint8_t *seg = NULL;
+	uint32_t oem_sig_size = 0;
+	uint32_t qc_cert_size = 0;
+	uint32_t qc_meta_size = 0;
+	uint32_t qc_sig_size = 0;
+	size_t signed_size = 0;
+	uint32_t code_size = 0;
+	uint32_t version = 0;
+	size_t hdr_size = 0;
+	size_t seg_size = 0;
+	size_t cursor = 0;
+
+	if (!md || !md_size || !out || !hash_len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memset(out, 0, sizeof(*out));
+
+	res = pas_mbn_locate(md, md_size, &seg, &seg_size);
+	if (res)
+		return res;
+
+	if (seg_size < MBN_HDR_SIZE_V6)
+		return TEE_ERROR_BAD_FORMAT;
+
+	version = pas_mbn_read_u32(seg + MBN_OFF_VERSION);
+	if (version != PAS_MBN_VERSION_6) {
+		EMSG("PAS auth: unsupported MBN version %#"PRIx32, version);
+		return TEE_ERROR_BAD_FORMAT;
+	}
+	hdr_size = MBN_HDR_SIZE_V6;
+
+	/* "code_size" is the hash-table length in bytes, not a code length. */
+	code_size = pas_mbn_read_u32(seg + MBN_OFF_CODE_SIZE);
+	qc_sig_size = pas_mbn_read_u32(seg + MBN_OFF_QC_SIG_SIZE);
+	qc_cert_size = pas_mbn_read_u32(seg + MBN_OFF_QC_CERT_SIZE);
+	oem_sig_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_SIG_SIZE);
+	oem_cert_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_CERT_SIZE);
+	qc_meta_size = pas_mbn_read_u32(seg + MBN_OFF_QC_META_SIZE);
+	oem_meta_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_META_SIZE);
+
+	if (!code_size || code_size % hash_len)
+		return TEE_ERROR_BAD_FORMAT;
+
+	/*
+	 * Payload after the header:
+	 *   [qc_meta][oem_meta][hash table][qc_sig][qc_cert][oem_sig][oem_cert]
+	 * The signed region spans the header plus
+	 * [qc_meta || oem_meta || hash table].
+	 */
+	cursor = hdr_size;
+	out->signed_region = seg;
+
+	if (ADD_OVERFLOW(qc_meta_size, oem_meta_size, &signed_size) ||
+	    ADD_OVERFLOW(signed_size, code_size, &signed_size) ||
+	    ADD_OVERFLOW(signed_size, hdr_size, &signed_size))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (signed_size > seg_size)
+		return TEE_ERROR_BAD_FORMAT;
+	out->signed_region_size = signed_size;
+
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, qc_meta_size,
+				     &out->qti_meta, &out->qti_meta_size);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, oem_meta_size,
+				     &out->oem_meta, &out->oem_meta_size);
+	if (res)
+		return res;
+
+	out->hash_table = seg + cursor;
+	out->hash_table_size = code_size;
+	out->hash_len = hash_len;
+	out->num_entries = code_size / hash_len;
+	cursor += code_size;
+
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, qc_sig_size,
+				     &out->qti_sig, &out->qti_sig_size);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, qc_cert_size,
+				     &out->qti_certs, &out->qti_certs_size);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, oem_sig_size,
+				     &out->oem_sig, &out->oem_sig_size);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, oem_cert_size,
+				     &out->oem_certs, &out->oem_certs_size);
+	if (res)
+		return res;
+
+	out->version = version;
+
+	if (cursor + sizeof(uint32_t) <= seg_size &&
+	    pas_mbn_read_u32(seg + cursor) == UIE_ENC_PARAM_MAGIC)
+		out->uie_encrypted = true;
+
+	return TEE_SUCCESS;
+}

--- a/ta/qcom_pas/src/pas_meta.c
+++ b/ta/qcom_pas/src/pas_meta.c
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <pas_mbn_parser_priv.h>
+#include <pas_meta.h>
+#include <tee_internal_api.h>
+#include <utee_defines.h>
+
+TEE_Result pas_meta_get_version(const uint8_t *meta_data,
+				size_t meta_data_size, uint32_t *version)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	const uint8_t *seg = NULL;
+	size_t seg_size = 0;
+
+	if (!meta_data || !meta_data_size || !version)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = pas_mbn_locate(meta_data, meta_data_size, &seg, &seg_size);
+	if (res)
+		return res;
+
+	if (seg_size < MBN_OFF_VERSION + sizeof(uint32_t))
+		return TEE_ERROR_BAD_FORMAT;
+
+	*version = pas_mbn_read_u32(seg + MBN_OFF_VERSION);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_meta_segment_hash_len(const uint8_t *meta_data,
+				     size_t meta_data_size, uint32_t *hash_len)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t version = 0;
+
+	if (!hash_len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = pas_meta_get_version(meta_data, meta_data_size, &version);
+	if (res)
+		return res;
+
+	switch (version) {
+	case PAS_MBN_VERSION_6:
+		*hash_len = TEE_SHA384_HASH_SIZE;
+		return TEE_SUCCESS;
+	default:
+		EMSG("PAS auth: unsupported MBN version %#"PRIx32, version);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+}

--- a/ta/qcom_pas/src/qcom_pas.c
+++ b/ta/qcom_pas/src/qcom_pas.c
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
+#include <pas_auth.h>
 #include <pta_qcom_pas.h>
+#include <qcom_pas_priv.h>
 #include <ta_qcom_pas.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
@@ -13,21 +15,63 @@
 static size_t session_refcount;
 static TEE_TASessionHandle pta_session;
 
-static TEE_Result qcom_pas_auth_and_reset(uint32_t pt,
+static TEE_Result qcom_pas_init_image(struct qcom_pas_session *s, uint32_t pt,
+				      TEE_Param params[TEE_NUM_PARAMS])
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
+				  PTA_QCOM_PAS_INIT_IMAGE, pt, params, NULL);
+	if (res)
+		return res;
+
+	res = pas_auth_save_metadata(s, pt, params);
+	if (res)
+		return res;
+
+	return pas_auth_authenticate(s, params[0].value.a);
+}
+
+static TEE_Result qcom_pas_auth_and_reset(struct qcom_pas_session *s,
+					  uint32_t pt,
 					  TEE_Param params[TEE_NUM_PARAMS])
 {
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 						TEE_PARAM_TYPE_VALUE_INPUT,
 						TEE_PARAM_TYPE_MEMREF_INPUT,
 						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	/* Firmware authentication - TODO */
+	res = pas_auth_verify_reset(s, pta_session, params[0].value.a, params);
+	if (res)
+		return res;
 
 	return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
 				   PTA_QCOM_PAS_AUTH_AND_RESET,
 				   pt, params, NULL);
+}
+
+static TEE_Result qcom_pas_shutdown(struct qcom_pas_session *s, uint32_t pt,
+				    TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (pt != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
+				  PTA_QCOM_PAS_SHUTDOWN, pt, params, NULL);
+
+	pas_auth_release_metadata(s, params[0].value.a);
+
+	return res;
 }
 
 TEE_Result TA_CreateEntryPoint(void)
@@ -41,56 +85,78 @@ void TA_DestroyEntryPoint(void)
 
 TEE_Result TA_OpenSessionEntryPoint(uint32_t pt,
 				    TEE_Param params[TEE_NUM_PARAMS],
-				    void **sess __unused)
+				    void **sess_ctx)
 {
 	static const TEE_UUID uuid = PTA_QCOM_PAS_UUID;
-	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_PropSetHandle h = TEE_HANDLE_NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct qcom_pas_session *s = NULL;
 	TEE_Identity id = { };
 
 	res = TEE_AllocatePropertyEnumerator(&h);
-	if (res != TEE_SUCCESS)
-		goto error;
+	if (res)
+		goto out;
 
 	TEE_StartPropertyEnumerator(h, TEE_PROPSET_CURRENT_CLIENT);
 
 	res = TEE_GetPropertyAsIdentity(h, NULL, &id);
-	if (res != TEE_SUCCESS)
-		goto error;
+	if (res)
+		goto out;
 
 	if (id.login != TEE_LOGIN_REE_KERNEL) {
 		res = TEE_ERROR_ACCESS_DENIED;
-		goto error;
+		goto out;
+	}
+
+	s = TEE_Malloc(sizeof(*s), TEE_MALLOC_FILL_ZERO);
+	if (!s) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto out;
 	}
 
 	if (!session_refcount) {
 		res = TEE_OpenTASession(&uuid, TEE_TIMEOUT_INFINITE, pt, params,
 					&pta_session, NULL);
-		if (res != TEE_SUCCESS)
-			goto error;
+		if (res) {
+			TEE_Free(s);
+			goto out;
+		}
 	}
 
 	session_refcount++;
-	res = TEE_SUCCESS;
-error:
+	*sess_ctx = s;
+
+out:
 	if (h)
 		TEE_FreePropertyEnumerator(h);
 
 	return res;
 }
 
-void TA_CloseSessionEntryPoint(void *sess __unused)
+void TA_CloseSessionEntryPoint(void *sess_ctx)
 {
+	struct qcom_pas_session *s = sess_ctx;
+
+	if (s) {
+		size_t i = 0;
+
+		for (i = 0; i < PAS_MD_SLOTS; i++)
+			TEE_Free(s->slots[i].meta_data);
+		TEE_Free(s);
+	}
+
 	session_refcount--;
 
 	if (!session_refcount)
 		TEE_CloseTASession(pta_session);
 }
 
-TEE_Result TA_InvokeCommandEntryPoint(void *sess __unused, uint32_t cmd_id,
+TEE_Result TA_InvokeCommandEntryPoint(void *sess_ctx, uint32_t cmd_id,
 				      uint32_t pt,
 				      TEE_Param params[TEE_NUM_PARAMS])
 {
+	struct qcom_pas_session *s = sess_ctx;
+
 	switch (cmd_id) {
 	case TA_QCOM_PAS_IS_SUPPORTED:
 		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
@@ -101,9 +167,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *sess __unused, uint32_t cmd_id,
 					   PTA_QCOM_PAS_CAPABILITIES,
 					   pt, params, NULL);
 	case TA_QCOM_PAS_INIT_IMAGE:
-		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
-					   PTA_QCOM_PAS_INIT_IMAGE,
-					   pt, params, NULL);
+		return qcom_pas_init_image(s, pt, params);
 	case TA_QCOM_PAS_MEM_SETUP:
 		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
 					   PTA_QCOM_PAS_MEM_SETUP,
@@ -113,15 +177,13 @@ TEE_Result TA_InvokeCommandEntryPoint(void *sess __unused, uint32_t cmd_id,
 					   PTA_QCOM_PAS_GET_RESOURCE_TABLE,
 					   pt, params, NULL);
 	case TA_QCOM_PAS_AUTH_AND_RESET:
-		return qcom_pas_auth_and_reset(pt, params);
+		return qcom_pas_auth_and_reset(s, pt, params);
 	case TA_QCOM_PAS_SET_REMOTE_STATE:
 		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
 					   PTA_QCOM_PAS_SET_REMOTE_STATE,
 					   pt, params, NULL);
 	case TA_QCOM_PAS_SHUTDOWN:
-		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
-					   PTA_QCOM_PAS_SHUTDOWN,
-					   pt, params, NULL);
+		return qcom_pas_shutdown(s, pt, params);
 	default:
 		return TEE_ERROR_NOT_IMPLEMENTED;
 	}

--- a/ta/qcom_pas/src/sub.mk
+++ b/ta/qcom_pas/src/sub.mk
@@ -1,1 +1,3 @@
+global-incdirs-y += ../include
 srcs-y += qcom_pas.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_mbn_parser.c

--- a/ta/qcom_pas/src/sub.mk
+++ b/ta/qcom_pas/src/sub.mk
@@ -1,3 +1,3 @@
 global-incdirs-y += ../include
 srcs-y += qcom_pas.c
-srcs-$(CFG_QCOM_PAS_AUTH) += pas_mbn_parser.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth.c pas_mbn_parser.c pas_meta.c

--- a/ta/qcom_pas/user_ta.mk
+++ b/ta/qcom_pas/user_ta.mk
@@ -1,4 +1,9 @@
 user-ta-uuid := cff7d191-7ca0-4784-af13-48223b9a4fbe
 
-# PAS TA heap size can be customized if 4kB is not enough
+ifeq ($(CFG_QCOM_PAS_AUTH),y)
+CFG_PAS_TA_HEAP_SIZE ?= (512 * 1024)
+else
 CFG_PAS_TA_HEAP_SIZE ?= (4 * 1024)
+endif
+
+CFG_QCOM_PAS_AUTH ?= n


### PR DESCRIPTION
Adds the first layer of PIL firmware image authentication for the PAS
subsystem: the PTA re-hashes each loaded segment against the image's own
MBN hash table before releasing the peripheral from reset, so a
compromised REE cannot substitute firmware after the image metadata has
been accepted. Enabled on Lemans via `CFG_QCOM_PAS_AUTH`.

Signature authentication (certificate chain, device binding,
anti-rollback) is not part of this series; it is added on top of this in a
stacked follow-up, PR #20.

## Design

The implementation splits along the TEE trust boundary:

- **Segment hashing** lives in the PAS pseudo-TA (`pas_auth_core.c`), which
  can call `core_mmu_add_mapping()` to map the non-secure carveout. A user-TA
  cannot do this.

- **Metadata handling** lives in the `qcom_pas` user-TA (`pas_auth.c`), which
  saves a TEE-private copy of the INIT_IMAGE metadata blob and parses the MBN
  hash segment to extract the per-segment digest table.

The flow after this series:

```mermaid
sequenceDiagram
    participant REE as REE (Linux)
    participant TA as qcom_pas TA
    participant PTA as PAS PTA

    Note over REE,PTA: INIT_IMAGE - save metadata + MBN parse
    REE->>TA: INIT_IMAGE(pas_id, metadata_blob)
    TA->>PTA: PTA_QCOM_PAS_INIT_IMAGE
    PTA-->>TA: TEE_SUCCESS
    TA->>TA: pas_auth_save_metadata()<br/>TEE-private copy keyed by pas_id
    TA->>TA: pas_auth_authenticate()<br/>pas_mbn_parse() extracts hash_table
    Note right of TA: MBN parse only, no signature auth in this series
    TA-->>REE: TEE_SUCCESS

    Note over REE,PTA: MEM_SETUP - record carveout coordinates
    REE->>TA: MEM_SETUP(pas_id, fw_base, fw_size)
    TA->>PTA: PTA_QCOM_PAS_MEM_SETUP
    PTA-->>TA: TEE_SUCCESS
    TA-->>REE: TEE_SUCCESS

    Note over REE,PTA: REE loads segments into carveout, no TEE involvement

    Note over REE,PTA: AUTH_AND_RESET - segment hash verification + release
    REE->>TA: AUTH_AND_RESET(pas_id, fw_base, fw_size)
    TA->>PTA: PTA_QCOM_PAS_VERIFY_IMAGE with metadata and hash_table
    PTA->>PTA: map carveout MEM_AREA_RAM_NSEC
    loop for each PT_LOAD segment
        PTA->>PTA: SHA-256/384 then consttime_memcmp vs hash_table entry
    end
    PTA->>PTA: unmap carveout
    PTA-->>TA: TEE_SUCCESS all segments verified
    TA->>PTA: PTA_QCOM_PAS_AUTH_AND_RESET
    PTA-->>TA: TEE_SUCCESS peripheral released from reset
    TA-->>REE: TEE_SUCCESS
```

> If any segment digest mismatches, `PTA_QCOM_PAS_VERIFY_IMAGE` returns
> `TEE_ERROR_SECURITY` and `PTA_QCOM_PAS_AUTH_AND_RESET` is **never invoked**;
> the peripheral stays in reset.

> Signature authentication (cert chain, root-of-trust, SW/HW bindings,
> anti-rollback) is **not present in this series**; it is added in the stacked
> follow-up PR #20.

## Testing

- Built `PLATFORM=qcom-lemans CFG_QCOM_PAS_AUTH=y CFG_WERROR=y`; checkpatch
  clean across the series.
- On a Lemans board: valid, correctly-hashed images load and the peripheral is
  released from reset; an image with a corrupted/mismatched segment digest is
  rejected at `AUTH_AND_RESET` and the peripheral stays in reset, with no side
  effects on subsequent loads.