### PR TITLE
plat-qcom: add shikra platform enablement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,7 @@ jobs:
               _make PLATFORM=qcom-ipq52xx
               _make PLATFORM=qcom-nord
               _make PLATFORM=qcom-cacao
+              _make PLATFORM=qcom-shikra
           - name: arm rockchip
             make_commands: |
               _make PLATFORM=rockchip-px30

--- a/core/arch/arm/plat-qcom/bruin/arch_config.h
+++ b/core/arch/arm/plat-qcom/bruin/arch_config.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef ARCH_CONFIG_H
+#define ARCH_CONFIG_H
+
+#define GICD_BASE			UL(0x0f200000)
+#define GICR_BASE			UL(0x0f260000)
+
+#endif /* ARCH_CONFIG_H */

--- a/core/arch/arm/plat-qcom/bruin/qcom-arch.mk
+++ b/core/arch/arm/plat-qcom/bruin/qcom-arch.mk
@@ -1,0 +1,11 @@
+# BRUIN architecture configuration
+
+include core/arch/arm/cpu/cortex-armv8-0.mk
+$(call force,CFG_TEE_CORE_NB_CORE,4)
+$(call force,CFG_ARM_GICV3,y)
+
+CFG_TZDRAM_START ?= 0xa1400000
+CFG_TEE_RAM_VA_SIZE ?= 0x400000
+CFG_TA_RAM_VA_SIZE ?= 0x2100000
+CFG_TZDRAM_SIZE ?= (CFG_TEE_RAM_VA_SIZE + CFG_TA_RAM_VA_SIZE)
+CFG_NUM_THREADS ?= 4

--- a/core/arch/arm/plat-qcom/bruin/shikra/target_config.h
+++ b/core/arch/arm/plat-qcom/bruin/shikra/target_config.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef TARGET_CONFIG_H
+#define TARGET_CONFIG_H
+
+#define DRAM0_BASE			UL(0x80000000)
+#define DRAM0_SIZE			UL(0x80000000)
+
+#define GENI_UART_REG_BASE		UL(0x04a80000)
+
+#define IMEM_BASE			UL(0x0c100000)
+#define IMEM_SIZE			UL(0x00020000)
+
+#endif /* TARGET_CONFIG_H */

--- a/core/arch/arm/plat-qcom/bruin/sub.mk
+++ b/core/arch/arm/plat-qcom/bruin/sub.mk
@@ -1,0 +1,1 @@
+# Placeholder for Qcom architecture specific makefile

--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -32,6 +32,7 @@ supported-ta-targets ?= ta_arm64
 HOYA_ARCH_CHIPSETS := kodiak lemans
 BOBCAT_ARCH_CHIPSETS := ipq96xx ipq52xx
 WILDCAT_ARCH_CHIPSETS := nord cacao
+BRUIN_ARCH_CHIPSETS := shikra
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),$(HOYA_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := hoya
@@ -39,6 +40,8 @@ else ifneq (,$(filter $(PLATFORM_FLAVOR),$(BOBCAT_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := bobcat
 else ifneq (,$(filter $(PLATFORM_FLAVOR),$(WILDCAT_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := wildcat
+else ifneq (,$(filter $(PLATFORM_FLAVOR),$(BRUIN_ARCH_CHIPSETS)))
+QCOM_ARCH_FAMILY := bruin
 else
 $(error Unsupported PLATFORM_FLAVOR: $(PLATFORM_FLAVOR))
 endif


### PR DESCRIPTION
Add initial OP-TEE OS support for the Shikra platform under the new Bruin architecture family. This includes:

- conf.mk: register BRUIN_ARCH_CHIPSETS (shikra) and add bruin family selection in the arch family mapping logic
- bruin/arch_config.h: GIC, PIMEM, PRNG, security control and TCSR base addresses for the Bruin architecture
- bruin/qcom-arch.mk: Bruin arch config — Cortex-ARMv8-0, 4-core GICv3, TZDRAM layout and feature flag defaults
- bruin/shikra/target_config.h: Shikra-specific DRAM, UART, IMEM and PIMEM vault base addresses
- bruin/shikra/target.mk: Shikra target-level feature flag overrides

Change-Id: I4f3bff38a3214e174d5894625607f95c13900e4b

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
