### PR TITLE
qcom: Add platform support for Rolas

### DIFF
--- a/core/arch/arm/plat-qcom/bobcat/qcom-arch.mk
+++ b/core/arch/arm/plat-qcom/bobcat/qcom-arch.mk
@@ -1,4 +1,13 @@
 # SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 
+$(call force,CFG_GIC,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,40)
+$(call force,CFG_QCOM_GENI_UART,y)
+
+# The GENI UART is shared with the Linux kernel and an excessively long
+# wait period may lead to RCU stall warnings depending on system load.
+# Make this value configurable per platform.
+CFG_QCOM_GENI_UART_RDY_WAIT_USEC ?= 1000
+
 CFG_QCOM_SEC_WDOG ?= y

--- a/core/arch/arm/plat-qcom/conf.mk
+++ b/core/arch/arm/plat-qcom/conf.mk
@@ -9,21 +9,13 @@ PLATFORM_FLAVOR ?= kodiak
 # so we need to set it early here also.
 CFG_INSECURE ?= y
 
-$(call force,CFG_GIC,y)
 $(call force,CFG_SECURE_TIME_SOURCE_CNTPCT,y)
 $(call force,CFG_ARM64_core,y)
 $(call force,CFG_WITH_ARM_TRUSTED_FW,y)
-$(call force,CFG_CORE_ARM64_PA_BITS,40)
 $(call force,CFG_CORE_LARGE_PHYS_ADDR,y)
 $(call force,CFG_CORE_RESERVED_SHM,n)
-$(call force,CFG_QCOM_GENI_UART,y)
 $(call force,CFG_CRYPTO_WITH_CE,y)
 $(call force,CFG_HW_UNIQUE_KEY_LENGTH,32)
-
-# The GENI UART is shared with the Linux kernel and an excessively long
-# wait period may lead to RCU stall warnings depending on system load.
-# Make this value configurable per platform.
-CFG_QCOM_GENI_UART_RDY_WAIT_USEC ?= 1000
 
 ta-targets = ta_arm64
 supported-ta-targets ?= ta_arm64
@@ -31,7 +23,7 @@ supported-ta-targets ?= ta_arm64
 # Architecture family mapping
 HOYA_ARCH_CHIPSETS := kodiak lemans
 BOBCAT_ARCH_CHIPSETS := ipq96xx ipq52xx
-WILDCAT_ARCH_CHIPSETS := nord
+WILDCAT_ARCH_CHIPSETS := nord rolas
 
 ifneq (,$(filter $(PLATFORM_FLAVOR),$(HOYA_ARCH_CHIPSETS)))
 QCOM_ARCH_FAMILY := hoya

--- a/core/arch/arm/plat-qcom/hoya/qcom-arch.mk
+++ b/core/arch/arm/plat-qcom/hoya/qcom-arch.mk
@@ -3,6 +3,15 @@
 include core/arch/arm/cpu/cortex-armv8-0.mk
 $(call force,CFG_TEE_CORE_NB_CORE,8)
 
+$(call force,CFG_GIC,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,40)
+$(call force,CFG_QCOM_GENI_UART,y)
+
+# The GENI UART is shared with the Linux kernel and an excessively long
+# wait period may lead to RCU stall warnings depending on system load.
+# Make this value configurable per platform.
+CFG_QCOM_GENI_UART_RDY_WAIT_USEC ?= 1000
+
 $(call force,CFG_QCOM_RAMBLUR_PIMEM_V3,y)
 CFG_QCOM_RAMBLUR_TA_WINDOW_ID ?= 2
 

--- a/core/arch/arm/plat-qcom/main.c
+++ b/core/arch/arm/plat-qcom/main.c
@@ -5,8 +5,15 @@
  */
 
 #include <console.h>
+#ifdef CFG_GIC
 #include <drivers/gic.h>
+#endif
+#ifdef CFG_QCOM_GENI_UART
 #include <drivers/qcom_geni_uart.h>
+#endif
+#ifdef CFG_PL011
+#include <drivers/pl011.h>
+#endif
 #include <kernel/boot.h>
 #include <mm/core_mmu.h>
 #include <platform_config.h>
@@ -17,9 +24,15 @@
  * Register the physical memory area for peripherals etc. Here we are
  * registering the UART console.
  */
+#ifdef CFG_QCOM_GENI_UART
 register_phys_mem_pgdir(MEM_AREA_IO_NSEC, GENI_UART_REG_BASE,
 			GENI_UART_REG_SIZE);
+#endif
+#ifdef CFG_PL011
+register_phys_mem_pgdir(MEM_AREA_IO_NSEC, CONSOLE_UART_BASE, PL011_UART_SIZE);
+#endif
 
+#ifdef CFG_GIC
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICD_BASE, GIC_DIST_REG_SIZE);
 #ifdef _CFG_ARM_V3_OR_V4
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE,
@@ -27,13 +40,19 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICR_BASE,
 #else
 register_phys_mem_pgdir(MEM_AREA_IO_SEC, GICC_BASE, GIC_CPU_REG_SIZE);
 #endif
+#endif /* CFG_GIC */
 
 register_ddr(DRAM0_BASE, DRAM0_SIZE);
 #ifdef DRAM1_BASE
 register_ddr(DRAM1_BASE, DRAM1_SIZE);
 #endif
 
+#ifdef CFG_QCOM_GENI_UART
 static struct qcom_geni_uart_data console_data;
+#endif
+#ifdef CFG_PL011
+static struct pl011_data console_data;
+#endif
 
 void plat_trace_ext_puts(const char *str)
 {
@@ -47,8 +66,14 @@ void plat_trace_init(void)
 
 void plat_console_init(void)
 {
+#ifdef CFG_QCOM_GENI_UART
 	qcom_geni_uart_init(&console_data, GENI_UART_REG_BASE);
 	register_serial_console(&console_data.chip);
+#endif
+#ifdef CFG_PL011
+	pl011_init(&console_data, CONSOLE_UART_BASE, 0, 0);
+	register_serial_console(&console_data.chip);
+#endif
 }
 
 static TEE_Result platform_banner(void)
@@ -60,6 +85,7 @@ static TEE_Result platform_banner(void)
 
 boot_final(platform_banner);
 
+#ifdef CFG_GIC
 void boot_primary_init_intc(void)
 {
 #ifdef _CFG_ARM_V3_OR_V4
@@ -73,3 +99,4 @@ void boot_secondary_init_intc(void)
 {
 	gic_init_per_cpu();
 }
+#endif /* CFG_GIC */

--- a/core/arch/arm/plat-qcom/wildcat/nord/target.mk
+++ b/core/arch/arm/plat-qcom/wildcat/nord/target.mk
@@ -1,5 +1,25 @@
 # Nord (SA8797P / Oryon) OP-TEE platform.
 
+include core/arch/arm/cpu/cortex-armv8-0.mk
+
+$(call force,CFG_GIC,y)
+$(call force,CFG_ARM_GICV4,y)
+$(call force,CFG_QCOM_GENI_UART,y)
+$(call force,CFG_CORE_ARM64_PA_BITS,40)
+
+# The GENI UART is shared with the Linux kernel and an excessively long
+# wait period may lead to RCU stall warnings depending on system load.
+# Make this value configurable per platform.
+CFG_QCOM_GENI_UART_RDY_WAIT_USEC ?= 1000
+
+# DARE-TZ secure memory regions. DARE is another in-line memory encryption
+# IP similar to pIMEM but on wildcat arch it is setup by TME root-of-trust,
+# no specific driver needed in OP-TEE for that.
+CFG_TZDRAM_START ?= 0xBC280000
+CFG_TEE_RAM_VA_SIZE ?= 0x00200000
+CFG_TA_RAM_VA_SIZE ?= 0x07B80000
+CFG_TZDRAM_SIZE ?= (CFG_TEE_RAM_VA_SIZE + CFG_TA_RAM_VA_SIZE)
+
 # Threads are expensive in OP-TEE, so they don't have
 # to be same as number of cores.
 $(call force,CFG_TEE_CORE_NB_CORE,18)

--- a/core/arch/arm/plat-qcom/wildcat/qcom-arch.mk
+++ b/core/arch/arm/plat-qcom/wildcat/qcom-arch.mk
@@ -1,15 +1,3 @@
 # Wildcat architecture configuration
 
-include core/arch/arm/cpu/cortex-armv8-0.mk
-
-$(call force,CFG_ARM_GICV4,y)
-
-# DARE-TZ secure memory regions. DARE is another in-line
-# memory encryption IP similar to pIMEM but on wildcat arch
-# it is setup by TME root-of-trust, no specific driver needed
-# in OP-TEE for that.
-CFG_TZDRAM_START ?= 0xBC280000
-CFG_TEE_RAM_VA_SIZE ?= 0x00200000
-CFG_TA_RAM_VA_SIZE ?= 0x07B80000
-CFG_TZDRAM_SIZE ?= (CFG_TEE_RAM_VA_SIZE + CFG_TA_RAM_VA_SIZE)
 CFG_NUM_THREADS ?= 8

--- a/core/arch/arm/plat-qcom/wildcat/rolas/fdts/optee_sp_manifest.dts
+++ b/core/arch/arm/plat-qcom/wildcat/rolas/fdts/optee_sp_manifest.dts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+ *
+ * This file is a Partition Manifest (PM) for OP-TEE as a Secure Partition (SP)
+ * for ROLAS platform with Hafnium SPMC
+ */
+
+/dts-v1/;
+
+/ {
+	compatible = "arm,ffa-manifest-1.0";
+
+	/* Properties */
+	description = "op-tee-rolas";
+	ffa-version = <0x00010002>; /* 31:16 - Major, 15:0 - Minor */
+	uuid = <0xe0786148 0xe311f8e7 0x02005ebc 0x1bc5d5a5>;
+	id = <1>;
+	execution-ctx-count = <8>;
+	exception-level = <2>; /* S-EL1 */
+	execution-state = <0>; /* AARCH64 */
+	load-address = <0x00 0xF8200000>; /* 0xF8200000 */
+	mem-size = <0x00 0x00A00000>; /* 10MB */
+	entrypoint-offset = <0x4000>;
+	xlat-granule = <0>; /* 4KiB */
+	boot-order = <0>;
+	messaging-method = <0x3>; /* Direct request/response supported */
+	notification-support; /* Receipt of notifications */
+
+	/* Boot protocol */
+	gp-register-num = <0x0>;
+	boot-info {
+		compatible = "arm,ffa-manifest-boot-info";
+		ffa_manifest;
+	};
+
+	device-regions {
+		compatible = "arm,ffa-manifest-device-regions";
+
+		/* PL011 UART for ROLAS */
+		uart {
+			base-address = <0x00000010 0x0C800000>;
+			pages-count = <1>;
+			attributes = <0x3>; /* read-write */
+		};
+	};
+};

--- a/core/arch/arm/plat-qcom/wildcat/rolas/target.mk
+++ b/core/arch/arm/plat-qcom/wildcat/rolas/target.mk
@@ -1,0 +1,31 @@
+# ROLAS (Hafnium SPMC-only) OP-TEE platform.
+
+# ROLAS is an ARMv9.3-A core. This toolchain has no -march/-mcpu support
+# for ARMv9.3-A yet (GCC's newest recognized Arm core here is Neoverse V2,
+# ARMv9.0-A), so build for Neoverse V2 as an ARMv9.0-A baseline until the
+# toolchain gains ARMv9.3-A support.
+include core/arch/arm/cpu/neoverse-v2.mk
+
+# ROLAS runs exclusively under Hafnium SPMC (S-EL2): interrupts are
+# distributed by the SPMC rather than a directly-owned GIC, and the
+# console is a PL011 instead of the other wildcat chipsets' own UART.
+$(call force,CFG_CORE_FFA,y)
+$(call force,CFG_CORE_SEL2_SPMC,y)
+$(call force,CFG_GIC,n)
+$(call force,CFG_ARM_GICV3,n)
+$(call force,CFG_ARM_GICV4,n)
+$(call force,CFG_PL011,y)
+
+# ROLAS uses 48-bit PA instead of the other wildcat chipsets' 40-bit.
+$(call force,CFG_CORE_ARM64_PA_BITS,48)
+
+$(call force,CFG_TEE_CORE_NB_CORE,8)
+CFG_NUM_THREADS ?= 8
+
+# SPMC memory layout: load address 0xF8200000 (see manifest), entry point
+# is load_address + manifest size (0x4000). ROLAS gets its TZDRAM layout
+# from its FF-A partition manifest rather than the wildcat DARE-TZ default.
+CFG_TZDRAM_START ?= 0xF8204000
+CFG_TEE_RAM_VA_SIZE ?= 0x00200000
+CFG_TA_RAM_VA_SIZE ?= 0x007fc000
+CFG_TZDRAM_SIZE ?= (CFG_TEE_RAM_VA_SIZE + CFG_TA_RAM_VA_SIZE)

--- a/core/arch/arm/plat-qcom/wildcat/rolas/target_config.h
+++ b/core/arch/arm/plat-qcom/wildcat/rolas/target_config.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef TARGET_CONFIG_H
+#define TARGET_CONFIG_H
+
+#define PL011_UART_BASE			ULL(0x100C800000)
+#define PL011_UART_SIZE			UL(0x1000)
+#define CONSOLE_UART_BASE		PL011_UART_BASE
+
+#define DRAM0_BASE			ULL(0x80000000)
+#define DRAM0_SIZE			ULL(0x80000000)
+
+#endif /* TARGET_CONFIG_H */


### PR DESCRIPTION
Rolas is a wildcat-family platform that runs OP-TEE as an S-EL1 FF-A secure partition under Hafnium SPMC, so it disables CFG_GIC and uses a PL011 console instead of the wildcat family's default GIC/GENI UART setup. Its FF-A partition manifest defines the load address and memory size, from which its TZDRAM layout is derived. Rolas also uses 48-bit physical addressing.

Validated with a native build for PLATFORM_FLAVOR=rolas and the other qcom flavors (ipq96xx, ipq52xx, kodiak, lemans, nord); checkpatch reports no issues.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
