### PR TITLE
Enable PIL authentication for Qualcomm Wildcat/Nord platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/compile_commands.json
-/cscope.*
+compile_commands.json
+cscope.*
 /tags
 /TAGS
 /out

--- a/core/arch/arm/plat-qcom/hoya/lemans/target.mk
+++ b/core/arch/arm/plat-qcom/hoya/lemans/target.mk
@@ -7,12 +7,6 @@ ifneq ($(CFG_INSECURE),y)
 CFG_QCOM_QFPROM_FUSEPROV ?= y
 endif
 
-ifeq ($(CFG_QCOM_QFPROM_FUSEPROV),y)
-$(call force,CFG_QCOM_CMD_DB,y)
-$(call force,CFG_QCOM_RPMH_CLIENT,y)
-$(call force,CFG_QCOM_QFPROM,y)
-endif
-
 CFG_QCOM_PAS_PTA ?= y
 
 ifeq ($(CFG_QCOM_PAS_PTA),y)
@@ -22,12 +16,10 @@ ifeq ($(CFG_QCOM_PAS_PTA),y)
 CFG_RESERVED_VASPACE_SIZE ?= (256 * 1024 * 1024)
 CFG_IN_TREE_EARLY_TAS += qcom_pas/cff7d191-7ca0-4784-af13-48223b9a4fbe
 
-# Verify PIL firmware at AUTH_AND_RESET: re-hash the segments the REE loaded
-# and compare them against the per-segment hash table in the image metadata,
-# before releasing the peripheral from reset.
-#
-# TODO: signature authentication of that hash table (certificate chain and
-# fuse bindings) will be added incrementally.
+# Authenticate PIL firmware: at INIT_IMAGE validate the certificate chain,
+# signature and fuse bindings, then at AUTH_AND_RESET re-hash the loaded
+# segments against the authenticated per-segment hash table before releasing
+# the peripheral from reset.
 CFG_QCOM_PAS_AUTH ?= y
 
 # Lemans exposes up to 7 PAS subsystems that load concurrently; size the
@@ -35,3 +27,23 @@ CFG_QCOM_PAS_AUTH ?= y
 CFG_PAS_MD_SLOTS ?= 8
 endif
 CFG_QCOM_HWKM ?= y
+
+# Signature authentication reads the OEM root-of-trust anchor, device identity
+# and other fuses via the fuse PTA; enable it (and therefore the underlying
+# qfprom driver) whenever PAS authentication is on.
+ifeq ($(CFG_QCOM_PAS_AUTH),y)
+$(call force,CFG_QCOM_FUSE_PTA,y)
+endif
+
+# QFPROM backs fuse provisioning (writes) and the fuse PTA (reads) alike;
+# enable the driver whenever either consumer is on.
+ifneq ($(filter y,$(CFG_QCOM_QFPROM_FUSEPROV) $(CFG_QCOM_FUSE_PTA)),)
+$(call force,CFG_QCOM_QFPROM,y)
+endif
+
+# CMD_DB/RPMH_CLIENT back the qfprom driver's fuse-write path (voltage rail
+# sequencing), needed whenever qfprom itself is enabled.
+ifeq ($(CFG_QCOM_QFPROM),y)
+$(call force,CFG_QCOM_CMD_DB,y)
+$(call force,CFG_QCOM_RPMH_CLIENT,y)
+endif

--- a/core/arch/arm/plat-qcom/hoya/lemans/target.mk
+++ b/core/arch/arm/plat-qcom/hoya/lemans/target.mk
@@ -21,5 +21,17 @@ ifeq ($(CFG_QCOM_PAS_PTA),y)
 # fits only one, so reserve 256 MB with headroom.
 CFG_RESERVED_VASPACE_SIZE ?= (256 * 1024 * 1024)
 CFG_IN_TREE_EARLY_TAS += qcom_pas/cff7d191-7ca0-4784-af13-48223b9a4fbe
+
+# Verify PIL firmware at AUTH_AND_RESET: re-hash the segments the REE loaded
+# and compare them against the per-segment hash table in the image metadata,
+# before releasing the peripheral from reset.
+#
+# TODO: signature authentication of that hash table (certificate chain and
+# fuse bindings) will be added incrementally.
+CFG_QCOM_PAS_AUTH ?= y
+
+# Lemans exposes up to 7 PAS subsystems that load concurrently; size the
+# per-session metadata table to hold one slot per subsystem, with headroom.
+CFG_PAS_MD_SLOTS ?= 8
 endif
 CFG_QCOM_HWKM ?= y

--- a/core/arch/arm/plat-qcom/wildcat/arch_config.h
+++ b/core/arch/arm/plat-qcom/wildcat/arch_config.h
@@ -9,4 +9,13 @@
 #define GICD_BASE			UL(0x17000000)
 #define GICR_BASE			UL(0x17080000)
 
+/*
+ * TME fuse-controller "sense register" sub-block (FUSE_CONTROLLER_SW_RANGE4
+ * in the reference register header), holding SECURE_BOOT, device-identity,
+ * OEM_CONFIG* and MRC fuse sense registers read by
+ * core/drivers/qcom/qfprom/nord/qfprom_target.h.
+ */
+#define SECURITY_CONTROL_BASE		UL(0x360d4000)
+#define SECURITY_CONTROL_SIZE		UL(0x4000)
+
 #endif /* ARCH_CONFIG_H */

--- a/core/arch/arm/plat-qcom/wildcat/nord/target.mk
+++ b/core/arch/arm/plat-qcom/wildcat/nord/target.mk
@@ -3,3 +3,33 @@
 # Threads are expensive in OP-TEE, so they don't have
 # to be same as number of cores.
 $(call force,CFG_TEE_CORE_NB_CORE,18)
+
+# CFG_QCOM_PAS_PTA enables PIL segment-hash verification (no fuse dependency).
+# It is disabled here because core/pta/qcom/pas/sub.mk unconditionally requires
+# platform/$(PLATFORM_FLAVOR)/sub.mk to exist, regardless of any CFG_QCOM_PAS_*
+# flag. That directory holds the per-subsystem PIL driver implementation
+# (subsys.c implementing qcom_pas_platform_subsys(), plus one .c/.h pair per
+# remoteproc peripheral — CDSP, LPASS, IRIS, etc. — with real register/clock/
+# reset sequencing for that subsystem on this chip). That platform-specific
+# driver code does not exist for Nord yet.
+#
+# To enable PAS for Nord:
+#   1. Create core/pta/qcom/pas/platform/nord/ with subsys.c and
+#      per-subsystem driver files (CDSP, LPASS, IRIS, etc.)
+#   2. Set CFG_QCOM_PAS_PTA ?= y below
+#
+# CFG_QCOM_PAS_AUTH (certificate chain, signature and fuse-bound binding
+# checks for PIL images) is nested inside the CFG_QCOM_PAS_PTA block, mirroring
+# lemans/target.mk, so it takes effect once the platform driver above exists
+# and CFG_QCOM_PAS_PTA is turned on. Fuse reads use sense registers (hardware
+# shadow of fuse rows) instead of the QFPROM driver, so no CFG_QCOM_QFPROM
+# dependency. See the "chore: use..." commit for the sense-register fuse
+# read implementation.
+#
+CFG_QCOM_PAS_PTA ?= n
+ifeq ($(CFG_QCOM_PAS_PTA),y)
+CFG_RESERVED_VASPACE_SIZE ?= (256 * 1024 * 1024)
+CFG_IN_TREE_EARLY_TAS += qcom_pas/cff7d191-7ca0-4784-af13-48223b9a4fbe
+CFG_QCOM_PAS_AUTH ?= y
+endif
+

--- a/core/drivers/qcom/qfprom/lemans/qfprom_target.h
+++ b/core/drivers/qcom/qfprom/lemans/qfprom_target.h
@@ -17,6 +17,67 @@
 #define QFPROM_CORR_BASE                        0x00784000
 #define QFPROM_SIZE                             0x4000
 
+/*
+ * SECURE_BOOTn secure-control register array holding the per-code-segment
+ * AUTH_EN and USE_SERIAL_NUM bits. Authentication is required when AUTH_EN
+ * is blown; the OEM root-of-trust anchor lives in the PK_HASH_0 fuse. The
+ * APPS code segment is index 1 within the array.
+ */
+#define SECURE_BOOT_APPS_ADDR			(SECURITY_CONTROL_BASE + 0x606c)
+#define SECURE_BOOT_AUTH_EN_BMSK		0x20
+#define SECURE_BOOT_USE_SERIAL_NUM_BMSK		0x40
+
+/*
+ * Size of the OEM root-of-trust digest stored in the PK_HASH_0 fuse region.
+ * SHA-384 (48 bytes) on this platform, matching the secure-boot ROM.
+ */
+#define QFPROM_ROOT_OF_TRUST_BYTE_SIZE		48
+
+/*
+ * Device-identity sense registers in the SECURITY_CONTROL block (hardware
+ * shadow of the underlying OEM_CONFIG / PTE fuse rows). Used to bind signed
+ * image metadata to this device.
+ */
+#define OEM_ID_SENSE_ADDR			(SECURITY_CONTROL_BASE + 0x6138)
+#define OEM_ID_BMSK				0xffff0000
+#define OEM_ID_SHFT				16
+#define MODEL_ID_BMSK				0x0000ffff
+#define MODEL_ID_SHFT				0
+#define JTAG_ID_SENSE_ADDR			(SECURITY_CONTROL_BASE + 0x6130)
+#define JTAG_ID_AUTH_BMSK			0x0fffffff
+#define SERIAL_NUM_SENSE_ADDR			(SECURITY_CONTROL_BASE + 0x6134)
+
+/*
+ * SOC hardware version lives in a TCSR register (not a fuse). The metadata
+ * soc_vers binding compares against the family|device field (bits 31:16).
+ */
+#define TCSR_SOC_HW_VERSION_ADDR		0x01FC8000
+#define SOC_HW_VERSION_FAM_DEV_BMSK		0xffff0000
+#define SOC_HW_VERSION_FAM_DEV_SHFT		16
+
+/*
+ * OEM_CONFIG2 fuse register (SECURITY_CONTROL block), holding the
+ * EKU_ENFORCEMENT_EN bit and the per-segment hash algorithm select bits
+ * below.
+ */
+#define OEM_CONFIG2_ADDR			(SECURITY_CONTROL_BASE + 0x6054)
+#define EKU_ENFORCEMENT_EN_SHFT			30
+
+/*
+ * Per-segment hash algorithm select: bit SEGMENT_HASH_FUNCTION_SELECT0_SHFT
+ * + root_cert_sel of OEM_CONFIG2 is indexed by the metadata's root_cert_sel
+ * field (0-3): bit set -> SHA-256, else -> SHA-384.
+ */
+#define SEGMENT_HASH_SELECT_SUPPORTED		1
+#define SEGMENT_HASH_FUNCTION_SELECT0_SHFT	16
+
+/*
+ * OEM_CONFIG0 fuse register (SECURITY_CONTROL block). IMAGE_ENCRYPTION_ENABLE
+ * indicates OEM image encryption is provisioned.
+ */
+#define OEM_CONFIG0_ADDR			(SECURITY_CONTROL_BASE + 0x604c)
+#define IMAGE_ENCRYPTION_ENABLE_SHFT		19
+
 #define QFPROM_BLOW_TIMER_OFFSET                0x2030
 #define QFPROM_ACCEL_OFFSET                     0x2038
 

--- a/core/drivers/qcom/qfprom/nord/qfprom_target.h
+++ b/core/drivers/qcom/qfprom/nord/qfprom_target.h
@@ -1,0 +1,176 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __QFPROM_TARGET_H__
+#define __QFPROM_TARGET_H__
+
+#include <clock_group_qcom.h>
+#include <platform_config.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+/*
+ * Nord's fuse controller is a TME (Trust Management Engine) sub-block
+ * rather than a standalone always-on QFPROM macro (confirmed via IPCatalog:
+ * both QFPROM_RAW and QFPROM_CORR are owned by the tme_fusecontroller
+ * component). The register blocks are still directly memory-mapped and
+ * readable via ordinary MMIO from the AP, matching how qfprom_read_row()
+ * already accesses QFPROM_RAW_BASE/QFPROM_CORR_BASE on hoya - no TME
+ * firmware call (TMECOMM) is required for these reads.
+ *
+ * QFPROM_RAW_BASE/QFPROM_CORR_BASE below are TME_FUSECONTROLLER_BASE-relative
+ * (0x360c0000 + 0x0/+0x8000), not the 0x0078xxxx range hoya uses; the two
+ * platforms' fuse controllers sit at different physical addresses.
+ */
+#define QFPROM_RAW_BASE                          0x360c0000
+#define QFPROM_CORR_BASE                         0x360c8000
+#define QFPROM_SIZE                              0x8000
+
+/*
+ * SECURE_BOOT secure-control register holding the AUTH_EN, PK_HASH_IN_FUSE
+ * and USE_SERIAL_NUM bits, plus ROM_PK_HASH_INDEX (which root-of-trust table
+ * entry the ROM selects when PK_HASH_IN_FUSE is not blown). Authentication
+ * is required when AUTH_EN is blown; the root-of-trust anchor lives in the
+ * PK_HASH fuse rows below rather than the ROM table when PK_HASH_IN_FUSE is
+ * blown.
+ *
+ * Unlike hoya's per-code-segment SECURE_BOOTn array, nord has a single
+ * SECURE_BOOT register (no code-segment index) - confirmed by
+ * secfuses/inc/nord/SecHWIO.h, whose secboot_read_secure_bootn_*() helpers
+ * all read this one address regardless of the code segment argument.
+ */
+#define SECURE_BOOT_APPS_ADDR			(SECURITY_CONTROL_BASE + 0x0704)
+#define SECURE_BOOT_AUTH_EN_BMSK		0x20
+#define SECURE_BOOT_USE_SERIAL_NUM_BMSK		0x40
+#define SECURE_BOOT_PK_HASH_IN_FUSE_BMSK	0x10
+
+/*
+ * Size of the OEM root-of-trust digest compared during authentication.
+ * SHA-384 (48 bytes), matching secboot_chipset.h's
+ * SECBOOT_OTP_ROOT_OF_TRUST_BYTE_SIZE definition for this platform and
+ * secboot_hw_sha3rot.c's SECBOOT_HASH_DIGEST_SIZE_SHA384 comparison length -
+ * both confirmed against the reference root-of-trust read/compare call
+ * despite the underlying PK_HASH fuse rows (below) spanning more bits than
+ * this.
+ */
+#define QFPROM_ROOT_OF_TRUST_BYTE_SIZE		48
+
+/*
+ * PIL subsystem anti-rollback fuse layout: NOT YET AVAILABLE for nord.
+ *
+ * Unlike hoya's single shared PIL_SUBSYSTEM0/1 counter, nord's reference
+ * anti-rollback implementation (tzbsp_arb_config.c) uses a separate
+ * QFPROM_CORR/RAW_ANTIROLLBACK_ROWn_LSB/MSB fuse-row pair per subsystem
+ * type (ADSP, ADSP1, ADSP2, CDSP, GVM, HCONFIG, camera, IPA, GPU microcode,
+ * OEM VM, ...), each gated by a common PIL_ANTI_ROLL_EN bit in OEM_CONFIG5.
+ * This has no single PIL_ARB_LSB/MSB pair to port faithfully, and the
+ * existing fuse-PTA/pas_fuse.c API (one PTA_QCOM_FUSE_GET/BLOW_PIL_ROLLBACK_
+ * VERSION call, no per-subsystem selector) would need to change shape to
+ * support it. Left undefined rather than defining a scope-narrowed
+ * approximation; CFG_QCOM_PAS_AUTH stays off for this platform until this
+ * is resolved (see core/arch/arm/plat-qcom/wildcat/nord/target.mk).
+ */
+
+/*
+ * Device-identity sense registers (hardware shadow of the underlying
+ * fuse rows), read via tzbsp_fusecontroller_hwio.h/SecHWIO.h in the
+ * reference. Used to bind signed image metadata to this device.
+ *
+ * Unlike hoya's single OEM_ID_SENSE_ADDR word packing both OEM_ID (bits
+ * 31:16) and MODEL_ID (bits 15:0), nord exposes OEM_ID and MODEL_ID
+ * (named OEM_HW_ID/OEM_PRODUCT_ID in the reference) as two separate
+ * 16-bit registers - each BMSK/SHFT pair below is kept for source
+ * compatibility with hoya's accessor shape even though nord's fields do
+ * not need a shift.
+ */
+#define OEM_ID_SENSE_ADDR			(SECURITY_CONTROL_BASE + 0x0800)
+#define OEM_ID_BMSK				0x0000ffff
+#define OEM_ID_SHFT				0
+#define MODEL_ID_SENSE_ADDR			(SECURITY_CONTROL_BASE + 0x0804)
+#define MODEL_ID_BMSK				0x0000ffff
+#define MODEL_ID_SHFT				0
+#define JTAG_ID_SENSE_ADDR			(SECURITY_CONTROL_BASE + 0x0844)
+#define JTAG_ID_AUTH_BMSK			0x0fffffff
+#define JTAG_ID_AUTH_SHFT			0
+/*
+ * Serial number sense register (named CHIP_UNIQUE_ID_0/SERIAL_NUM in the
+ * reference). 32-bit, full-word, matching hoya's field width; a second
+ * 32-bit CHIP_UNIQUE_ID_1/CHIP_ID register exists alongside it but is not
+ * part of the serial-number binding this driver's callers need.
+ */
+#define SERIAL_NUM_SENSE_ADDR			(SECURITY_CONTROL_BASE + 0x0710)
+
+/*
+ * SOC hardware version lives in a TCSR register (not a fuse), same as
+ * hoya. The metadata soc_vers binding compares against the family|device
+ * field (bits 31:16).
+ *
+ * UNCONFIRMED FOR NORD: this is hoya's address, carried over as a
+ * placeholder. Nord's TCSR HWIO register definitions were not found in the
+ * accessible fuse-controller register header (TCSR is generated as a
+ * separate IP block from the fuse controller, and no nord-specific TCSR
+ * header was located during this pass). Do not enable CFG_QCOM_PAS_AUTH for
+ * nord until this address is verified against a nord TCSR register spec -
+ * an unverified address here would make the SOC_HW_VERSION binding check
+ * silently read the wrong register.
+ */
+#define TCSR_SOC_HW_VERSION_ADDR		0x01FC8000
+#define SOC_HW_VERSION_FAM_DEV_BMSK		0xffff0000
+#define SOC_HW_VERSION_FAM_DEV_SHFT		16
+
+/*
+ * OEM_CONFIG2 fuse register, holding the EKU_ENFORCEMENT_EN bit at the same
+ * bit position as hoya. Nord's OEM_CONFIG2 does not carry a per-segment
+ * hash-algorithm-select field the way lemans's does; MBN v6 segment hashing
+ * on this platform always uses SHA-384, matching kodiak's
+ * SEGMENT_HASH_SELECT_SUPPORTED=0 behavior (confirmed absent: no
+ * SEGMENT_HASH_FUNCTION_SELECT field exists in nord's OEM_CONFIG2 register
+ * definition).
+ */
+#define OEM_CONFIG2_ADDR			(SECURITY_CONTROL_BASE + 0x0308)
+#define EKU_ENFORCEMENT_EN_SHFT			30
+
+#define SEGMENT_HASH_SELECT_SUPPORTED		0
+
+/*
+ * Multiple-root-certificate (MRC) fuse fields. Nord's MRC_0/MRC_1 register
+ * pair (SW_RANGE4 offsets 0x730/0x734) has a materially richer layout than
+ * hoya's single-word 4-bit activation/4-bit revocation model: MRC_0 packs
+ * QC_ROOT_CERT_ACTIVATION_LIST (bits 5:0), QC_ROOT_CERT_REVOCATION_LIST
+ * (bits 11:6), a 5-bit MRC_16_12 field, OEM_ROOT_CERT_ACTIVATION_LIST (bits
+ * 22:17), OEM_ROOT_CERT_REVOCATION_LIST (bits 28:23) and a 3-bit MRC_31_29
+ * field, with MRC_1 holding MRC_63_32. There is no single field matching
+ * hoya's ROOT_CERT_TOTAL_NUM/MRC_ACTIVATION_LIST/MRC_REVOCATION_LIST shape
+ * with 4-bit lists, and no evidence was found resolving what MRC_16_12/
+ * MRC_31_29/MRC_63_32 represent. Left undefined rather than mapping onto
+ * hoya's narrower model; MRC/root-selection support for this platform needs
+ * its own accessor design once these fields are understood, not a
+ * find-and-replace of hoya's macros.
+ *
+ * ROOT_CERT_TOTAL_NUM (number of provisioned roots - 1) is present at the
+ * same bit position hoya's kodiak/lemans use, but in the newer OEM_CONFIG5
+ * sense register rather than OEM_CONFIG0 - both an OEM_CONFIG5 location and
+ * a legacy QFPROM_RAW/CORR_OEM_CONFIG_ROW2_MSB location exist in the
+ * reference register header with identical bit position; OEM_CONFIG5 is
+ * used here for consistency with every other sense-register field above.
+ */
+#define OEM_CONFIG5_ADDR			(SECURITY_CONTROL_BASE + 0x0314)
+#define ROOT_CERT_TOTAL_NUM_BMSK		0x00000700
+#define ROOT_CERT_TOTAL_NUM_SHFT		8
+
+/* OEM_CONFIG5 PIL_ANTI_ROLL_EN: gates the (not yet ported) PIL ARB fuses. */
+#define PIL_ANTI_ROLLBACK_EN_BMSK		0x00000004
+
+/*
+ * OEM image encryption enable bit: not yet located for nord. Hoya's
+ * IMAGE_ENCRYPTION_ENABLE lives in OEM_CONFIG0; no equivalent field was
+ * found in nord's OEM_CONFIG0-OEM_CONFIG11 register definitions during this
+ * pass. Left undefined; a caller needing this must locate the field before
+ * relying on it.
+ */
+
+#endif /* __QFPROM_TARGET_H__ */

--- a/core/drivers/qcom/qfprom/qfprom_secboot.c
+++ b/core/drivers/qcom/qfprom/qfprom_secboot.c
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/*
+ * Secure-boot fuse accessors: OEM root-of-trust anchor and enable state,
+ * device identity, EKU/image-encryption enforcement and SoC HW version.
+ * Built only under CFG_QCOM_FUSE_PTA; other qfprom consumers live in
+ * qfprom_core.c.
+ */
+
+#include <inttypes.h>
+#include <io.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <string.h>
+#include <trace.h>
+#include <utee_defines.h>
+#include <util.h>
+
+#include "qfprom_priv.h"
+#include "qfprom_target.h"
+
+/*
+ * SOC_HW_VERSION is a TCSR register, so its mapping is registered here
+ * rather than in qfprom_core.c: only needed when these accessors are built.
+ */
+register_phys_mem_pgdir(MEM_AREA_IO_SEC, TCSR_SOC_HW_VERSION_ADDR,
+			CORE_MMU_PGDIR_SIZE);
+
+TEE_Result qcom_secboot_is_enabled(bool *enabled)
+{
+	struct qfprom_context *drv = qfprom_get_context();
+	uint32_t val = 0;
+
+	if (!enabled)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!drv->raw_base_va)
+		return TEE_ERROR_BAD_STATE;
+
+	val = io_read32(drv->raw_base_va +
+			(SECURE_BOOT_APPS_ADDR - SECURITY_CONTROL_BASE));
+	*enabled = (val & SECURE_BOOT_AUTH_EN_BMSK) != 0;
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Read the APPS SECURE_BOOTn USE_SERIAL_NUM bit: a device-fuse override
+ * that forces serial-number binding regardless of the image metadata's
+ * own serial-number-binding flag. Same register as
+ * qcom_secboot_is_enabled(), different bit.
+ */
+TEE_Result qcom_secboot_get_use_serial_num(bool *enabled)
+{
+	struct qfprom_context *drv = qfprom_get_context();
+	uint32_t val = 0;
+
+	if (!enabled)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!drv->raw_base_va)
+		return TEE_ERROR_BAD_STATE;
+
+	val = io_read32(drv->raw_base_va +
+			(SECURE_BOOT_APPS_ADDR - SECURITY_CONTROL_BASE));
+	*enabled = (val & SECURE_BOOT_USE_SERIAL_NUM_BMSK) != 0;
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Read one 32-bit corrected QFPROM word directly via its mapped virtual
+ * address, bypassing the region/permission table. Used for fuses that have no
+ * corrected-space region entry (e.g. the PK_HASH words); each caller documents
+ * why direct access is required.
+ */
+static TEE_Result read_corr_word(paddr_t pa, uint32_t mask, uint32_t *out)
+{
+	struct qfprom_context *drv = qfprom_get_context();
+	vaddr_t va = 0;
+
+	if (!drv->corr_base_va)
+		return TEE_ERROR_BAD_STATE;
+
+	va = drv->corr_base_va + (pa - QFPROM_CORR_BASE);
+	*out = io_read32(va) & mask;
+	return TEE_SUCCESS;
+}
+
+TEE_Result qcom_secboot_get_root_of_trust(uint8_t *hash, size_t len)
+{
+	paddr_t corr_base = QFPROM_RAW_TO_CORR(PK_HASH_0_ADDR);
+	size_t off = 0;
+
+	if (!hash)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (len != QFPROM_ROOT_OF_TRUST_BYTE_SIZE)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/*
+	 * qfprom_read_row() requires 8-byte-aligned addresses; use
+	 * read_corr_word() instead, which accepts 4-byte alignment.
+	 */
+	for (off = 0; off < len; off += sizeof(uint32_t)) {
+		TEE_Result res = TEE_ERROR_GENERIC;
+		uint32_t word = 0;
+
+		res = read_corr_word(corr_base + off, UINT32_MAX, &word);
+		if (res)
+			return res;
+
+		memcpy(hash + off, &word, MIN(sizeof(word), len - off));
+	}
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result read_sense_reg(paddr_t pa, uint32_t *out)
+{
+	struct qfprom_context *drv = qfprom_get_context();
+
+	if (!drv->raw_base_va)
+		return TEE_ERROR_BAD_STATE;
+
+	*out = io_read32(drv->raw_base_va + (pa - SECURITY_CONTROL_BASE));
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result qcom_secboot_get_device_ids(struct qcom_secboot_device_ids *ids)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t val = 0;
+
+	if (!ids)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = read_sense_reg(OEM_ID_SENSE_ADDR, &val);
+	if (res)
+		return res;
+	ids->oem_id = (val & OEM_ID_BMSK) >> OEM_ID_SHFT;
+	ids->model_id = (val & MODEL_ID_BMSK) >> MODEL_ID_SHFT;
+
+	res = read_sense_reg(JTAG_ID_SENSE_ADDR, &val);
+	if (res)
+		return res;
+	ids->jtag_id = val & JTAG_ID_AUTH_BMSK;
+
+	res = read_sense_reg(SERIAL_NUM_SENSE_ADDR, &ids->serial_num);
+	if (res)
+		return res;
+
+	return TEE_SUCCESS;
+}
+
+#define SEGMENT_HASH_ROOT_CERT_SEL_MAX	3U
+
+TEE_Result qcom_secboot_get_segment_hash_size(uint32_t root_cert_sel,
+					      uint32_t *hash_size)
+{
+	if (!hash_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (root_cert_sel > SEGMENT_HASH_ROOT_CERT_SEL_MAX)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+#if SEGMENT_HASH_SELECT_SUPPORTED
+	{
+		TEE_Result res = TEE_ERROR_GENERIC;
+		uint32_t val = 0;
+
+		res = read_sense_reg(OEM_CONFIG2_ADDR, &val);
+		if (res)
+			return res;
+
+		if (val & BIT32(SEGMENT_HASH_FUNCTION_SELECT0_SHFT +
+				root_cert_sel))
+			*hash_size = TEE_SHA256_HASH_SIZE;
+		else
+			*hash_size = TEE_SHA384_HASH_SIZE;
+	}
+#else
+	*hash_size = TEE_SHA384_HASH_SIZE;
+#endif
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Read the OEM_CONFIG2 EKU_ENFORCEMENT_EN bit: when blown, the leaf
+ * certificate's Extended Key Usage extension must carry the
+ * "Downloadable Code Signing" OID.
+ */
+TEE_Result qcom_secboot_get_eku_enforcement_en(bool *enabled)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t val = 0;
+
+	if (!enabled)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = read_sense_reg(OEM_CONFIG2_ADDR, &val);
+	if (res)
+		return res;
+
+	*enabled = val & BIT32(EKU_ENFORCEMENT_EN_SHFT);
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Read the IMAGE_ENCRYPTION_ENABLE bit of OEM_CONFIG0: when blown, OEM image
+ * encryption (UIE) is provisioned on the device.
+ */
+TEE_Result qcom_secboot_get_image_encryption_en(bool *enabled)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t val = 0;
+
+	if (!enabled)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = read_sense_reg(OEM_CONFIG0_ADDR, &val);
+	if (res)
+		return res;
+
+	*enabled = val & BIT32(IMAGE_ENCRYPTION_ENABLE_SHFT);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result qcom_secboot_get_soc_hw_version(uint32_t *fam_dev)
+{
+	vaddr_t va = 0;
+
+	if (!fam_dev)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	va = (vaddr_t)phys_to_virt(TCSR_SOC_HW_VERSION_ADDR, MEM_AREA_IO_SEC,
+				   sizeof(uint32_t));
+	if (!va) {
+		va = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_SEC,
+						   TCSR_SOC_HW_VERSION_ADDR,
+						   sizeof(uint32_t));
+		if (!va)
+			return TEE_ERROR_GENERIC;
+	}
+
+	*fam_dev = (io_read32(va) & SOC_HW_VERSION_FAM_DEV_BMSK) >>
+		   SOC_HW_VERSION_FAM_DEV_SHFT;
+
+	return TEE_SUCCESS;
+}

--- a/core/drivers/qcom/qfprom/qfprom_secboot.c
+++ b/core/drivers/qcom/qfprom/qfprom_secboot.c
@@ -31,18 +31,17 @@ register_phys_mem_pgdir(MEM_AREA_IO_SEC, TCSR_SOC_HW_VERSION_ADDR,
 
 TEE_Result qcom_secboot_is_enabled(bool *enabled)
 {
-	struct qfprom_context *drv = qfprom_get_context();
-	uint32_t val = 0;
+	vaddr_t va = 0;
 
 	if (!enabled)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (!drv->raw_base_va)
+	va = (vaddr_t)phys_to_virt(SECURE_BOOT_APPS_ADDR, MEM_AREA_IO_SEC,
+				   sizeof(uint32_t));
+	if (!va)
 		return TEE_ERROR_BAD_STATE;
 
-	val = io_read32(drv->raw_base_va +
-			(SECURE_BOOT_APPS_ADDR - SECURITY_CONTROL_BASE));
-	*enabled = (val & SECURE_BOOT_AUTH_EN_BMSK) != 0;
+	*enabled = (io_read32(va) & SECURE_BOOT_AUTH_EN_BMSK) != 0;
 
 	return TEE_SUCCESS;
 }
@@ -55,18 +54,17 @@ TEE_Result qcom_secboot_is_enabled(bool *enabled)
  */
 TEE_Result qcom_secboot_get_use_serial_num(bool *enabled)
 {
-	struct qfprom_context *drv = qfprom_get_context();
-	uint32_t val = 0;
+	vaddr_t va = 0;
 
 	if (!enabled)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	if (!drv->raw_base_va)
+	va = (vaddr_t)phys_to_virt(SECURE_BOOT_APPS_ADDR, MEM_AREA_IO_SEC,
+				   sizeof(uint32_t));
+	if (!va)
 		return TEE_ERROR_BAD_STATE;
 
-	val = io_read32(drv->raw_base_va +
-			(SECURE_BOOT_APPS_ADDR - SECURITY_CONTROL_BASE));
-	*enabled = (val & SECURE_BOOT_USE_SERIAL_NUM_BMSK) != 0;
+	*enabled = (io_read32(va) & SECURE_BOOT_USE_SERIAL_NUM_BMSK) != 0;
 
 	return TEE_SUCCESS;
 }
@@ -121,12 +119,13 @@ TEE_Result qcom_secboot_get_root_of_trust(uint8_t *hash, size_t len)
 
 static TEE_Result read_sense_reg(paddr_t pa, uint32_t *out)
 {
-	struct qfprom_context *drv = qfprom_get_context();
+	vaddr_t va = (vaddr_t)phys_to_virt(pa, MEM_AREA_IO_SEC,
+					   sizeof(uint32_t));
 
-	if (!drv->raw_base_va)
+	if (!va)
 		return TEE_ERROR_BAD_STATE;
 
-	*out = io_read32(drv->raw_base_va + (pa - SECURITY_CONTROL_BASE));
+	*out = io_read32(va);
 
 	return TEE_SUCCESS;
 }

--- a/core/drivers/qcom/qfprom/sub.mk
+++ b/core/drivers/qcom/qfprom/sub.mk
@@ -7,6 +7,7 @@ srcs-y += qfprom_core.c
 srcs-y += qfprom_hal.c
 srcs-y += qfprom_target.c
 srcs-y += $(PLATFORM_FLAVOR)/qfprom_fuse_region.c
+srcs-$(CFG_QCOM_FUSE_PTA) += qfprom_secboot.c
 
 global-incdirs-y += .
 global-incdirs-y += $(PLATFORM_FLAVOR)

--- a/core/include/drivers/qcom/qfprom/qfprom.h
+++ b/core/include/drivers/qcom/qfprom/qfprom.h
@@ -36,6 +36,115 @@ TEE_Result qfprom_read_row(uint32_t addr,
 			   enum qfprom_addr_space type,
 			   uint32_t *data);
 
+/*
+ * Report whether secure boot (image authentication) is enabled for the APPS
+ * code segment, i.e. whether the SECURE_BOOT AUTH_EN fuse is blown.
+ *
+ * @enabled: set to true if secure boot is enabled, false otherwise
+ *
+ * Return TEE_SUCCESS on success or an error if the state cannot be read.
+ */
+TEE_Result qcom_secboot_is_enabled(bool *enabled);
+
+/*
+ * Report whether the APPS SECURE_BOOTn USE_SERIAL_NUM fuse override is
+ * blown. When set, serial-number binding is forced regardless of the
+ * image metadata's own serial-number-binding flag.
+ *
+ * @enabled: set to true if the override is blown, false otherwise
+ *
+ * Return TEE_SUCCESS on success or an error if the state cannot be read.
+ */
+TEE_Result qcom_secboot_get_use_serial_num(bool *enabled);
+
+/*
+ * Read the OEM root-of-trust digest from the PK_HASH_0 fuse region. This is
+ * the hash the secure-boot ROM compares the firmware signing root certificate
+ * against. It is QFPROM_ROOT_OF_TRUST_BYTE_SIZE (48 bytes, SHA-384) on the
+ * supported platforms.
+ *
+ * @hash: output buffer for the digest
+ * @len:  size of @hash; must equal QFPROM_ROOT_OF_TRUST_BYTE_SIZE
+ *
+ * Return TEE_SUCCESS on success or an error if the value cannot be read.
+ */
+TEE_Result qcom_secboot_get_root_of_trust(uint8_t *hash, size_t len);
+
+/*
+ * Device-identity values read from the SECURITY_CONTROL sense registers,
+ * used to bind signed image metadata to this device.
+ *
+ * @oem_id:     OEM identifier (OEM_ID sense register, bits 31:16)
+ * @model_id:   product/model identifier (OEM_ID sense register, bits 15:0)
+ * @jtag_id:    JTAG ID masked to the authentication bits (0x0FFFFFFF)
+ * @serial_num: device serial number
+ */
+struct qcom_secboot_device_ids {
+	uint32_t oem_id;
+	uint32_t model_id;
+	uint32_t jtag_id;
+	uint32_t serial_num;
+};
+
+/*
+ * Read the device-identity fields (OEM_ID, MODEL_ID, JTAG_ID, serial number)
+ * from the SECURITY_CONTROL sense registers.
+ *
+ * @ids: populated on success
+ *
+ * Return TEE_SUCCESS on success or an error if the registers cannot be read.
+ */
+TEE_Result qcom_secboot_get_device_ids(struct qcom_secboot_device_ids *ids);
+
+/*
+ * Read the SOC hardware version family|device field (bits 31:16 of the TCSR
+ * SOC_HW_VERSION register), matching the value the metadata soc_vers binding
+ * compares against.
+ *
+ * @fam_dev: populated with the family|device number on success
+ *
+ * Return TEE_SUCCESS on success or an error if the register cannot be read.
+ */
+TEE_Result qcom_secboot_get_soc_hw_version(uint32_t *fam_dev);
+
+/*
+ * Read the digest size the per-segment hash table uses for a given
+ * root_cert_sel index: the OEM metadata's root_cert_sel (word 28, range
+ * 0-3) selects one of four OEM_CONFIG2 fuse bits on platforms that
+ * implement the field; the bit is 1 for SHA-256, 0 for SHA-384. Platforms
+ * without the field always report SHA-384.
+ *
+ * @root_cert_sel: metadata root_cert_sel index (0-3)
+ * @hash_size:     populated with the digest size in bytes (32 or 48)
+ *
+ * Return TEE_SUCCESS on success, TEE_ERROR_BAD_PARAMETERS if root_cert_sel is
+ * out of range.
+ */
+TEE_Result qcom_secboot_get_segment_hash_size(uint32_t root_cert_sel,
+					      uint32_t *hash_size);
+
+/*
+ * Read the OEM_CONFIG2 EKU_ENFORCEMENT_EN fuse bit. When enabled, image
+ * certificate chains must carry the code-signing Extended Key Usage OID
+ * on the leaf.
+ *
+ * @enabled: populated with the fuse bit's state on success
+ *
+ * Return TEE_SUCCESS on success or an error if the register cannot be read.
+ */
+TEE_Result qcom_secboot_get_eku_enforcement_en(bool *enabled);
+
+/*
+ * Read the OEM_CONFIG0 IMAGE_ENCRYPTION_ENABLE fuse bit. When blown, OEM image
+ * encryption (UIE) is provisioned: an image carrying UIE parameters is expected
+ * to be decrypted before use.
+ *
+ * @enabled: populated with the fuse bit's state on success
+ *
+ * Return TEE_SUCCESS on success or an error if the register cannot be read.
+ */
+TEE_Result qcom_secboot_get_image_encryption_en(bool *enabled);
+
 /* Write QFPROM row data */
 TEE_Result qfprom_write_row(uint32_t addr, uint32_t *data);
 

--- a/core/pta/qcom/fuse/pta_qcom_fuse.c
+++ b/core/pta/qcom/fuse/pta_qcom_fuse.c
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <drivers/qcom/qfprom/qfprom.h>
+#include <kernel/pseudo_ta.h>
+#include <kernel/ts_manager.h>
+#include <pta_qcom_fuse.h>
+#include <string.h>
+#include <tee_api_types.h>
+
+#define TA_PAS_UUID { 0xcff7d191, 0x7ca0, 0x4784, \
+		{ 0xaf, 0x13, 0x48, 0x22, 0x3b, 0x9a, 0x4f, 0xbe} }
+
+static TEE_Result get_secboot_state(uint32_t param_types,
+				    TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	bool en = false;
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = qcom_secboot_is_enabled(&en);
+	if (res)
+		return res;
+
+	params[0].value.a = en;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result get_root_of_trust(uint32_t param_types,
+				    TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_OUTPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (params[0].memref.size < PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE) {
+		params[0].memref.size = PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE;
+		return TEE_ERROR_SHORT_BUFFER;
+	}
+
+	params[0].memref.size = PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE;
+
+	return qcom_secboot_get_root_of_trust(params[0].memref.buffer,
+					      PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE);
+}
+
+static TEE_Result get_device_ids(uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	struct qcom_secboot_device_ids ids = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = qcom_secboot_get_device_ids(&ids);
+	if (res)
+		return res;
+
+	params[0].value.a = ids.oem_id;
+	params[0].value.b = ids.model_id;
+	params[1].value.a = ids.jtag_id;
+	params[1].value.b = ids.serial_num;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result get_soc_hw_version(uint32_t param_types,
+				     TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t fam_dev = 0;
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = qcom_secboot_get_soc_hw_version(&fam_dev);
+	if (res)
+		return res;
+
+	params[0].value.a = fam_dev;
+	return TEE_SUCCESS;
+}
+
+static TEE_Result get_segment_hash_size(uint32_t param_types,
+					TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INOUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t hash_size = 0;
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = qcom_secboot_get_segment_hash_size(params[0].value.a,
+						 &hash_size);
+	if (res)
+		return res;
+
+	params[0].value.b = hash_size;
+	return TEE_SUCCESS;
+}
+
+static TEE_Result get_eku_enforcement_en(uint32_t param_types,
+					 TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	bool en = false;
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = qcom_secboot_get_eku_enforcement_en(&en);
+	if (res)
+		return res;
+
+	params[0].value.a = en;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result get_use_serial_num(uint32_t param_types,
+				     TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	bool en = false;
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = qcom_secboot_get_use_serial_num(&en);
+	if (res)
+		return res;
+
+	params[0].value.a = en;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result get_image_encryption_en(uint32_t param_types,
+					  TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+	bool en = false;
+
+	if (param_types != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = qcom_secboot_get_image_encryption_en(&en);
+	if (res)
+		return res;
+
+	params[0].value.a = en;
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result invoke_command(void *sess_ctx __unused,
+				 uint32_t cmd_id,
+				 uint32_t param_types,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	switch (cmd_id) {
+	case PTA_QCOM_FUSE_GET_SECBOOT_STATE:
+		return get_secboot_state(param_types, params);
+	case PTA_QCOM_FUSE_GET_ROOT_OF_TRUST:
+		return get_root_of_trust(param_types, params);
+	case PTA_QCOM_FUSE_GET_DEVICE_IDS:
+		return get_device_ids(param_types, params);
+	case PTA_QCOM_FUSE_GET_SOC_HW_VERSION:
+		return get_soc_hw_version(param_types, params);
+	case PTA_QCOM_FUSE_GET_SEGMENT_HASH_SIZE:
+		return get_segment_hash_size(param_types, params);
+	case PTA_QCOM_FUSE_GET_EKU_ENFORCEMENT_EN:
+		return get_eku_enforcement_en(param_types, params);
+	case PTA_QCOM_FUSE_GET_USE_SERIAL_NUM:
+		return get_use_serial_num(param_types, params);
+	case PTA_QCOM_FUSE_GET_IMAGE_ENCRYPTION_EN:
+		return get_image_encryption_en(param_types, params);
+	default:
+		return TEE_ERROR_NOT_IMPLEMENTED;
+	}
+}
+
+/*
+ * Exposes fuse state to the qcom_pas TA only - no other TA or the REE may
+ * open a session.
+ */
+static TEE_Result open_session(uint32_t pt __unused,
+			       TEE_Param params[TEE_NUM_PARAMS] __unused,
+			       void **sess_ctx __unused)
+{
+	struct ts_session *s = ts_get_calling_session();
+	TEE_UUID ta_uuid = TA_PAS_UUID;
+	struct ts_ctx *ctx = NULL;
+
+	if (!s)
+		return TEE_ERROR_ACCESS_DENIED;
+
+	ctx = s->ctx;
+	if (memcmp(&ctx->uuid, &ta_uuid, sizeof(TEE_UUID)))
+		return TEE_ERROR_ACCESS_DENIED;
+
+	return TEE_SUCCESS;
+}
+
+pseudo_ta_register(.uuid = PTA_QCOM_FUSE_UUID,
+		   .name = "qcom_fuse.pta",
+		   .flags = PTA_DEFAULT_FLAGS,
+		   .open_session_entry_point = open_session,
+		   .invoke_command_entry_point = invoke_command);

--- a/core/pta/qcom/fuse/sub.mk
+++ b/core/pta/qcom/fuse/sub.mk
@@ -1,0 +1,1 @@
+srcs-y += pta_qcom_fuse.c

--- a/core/pta/qcom/pas/pas_auth_core.c
+++ b/core/pta/qcom/pas/pas_auth_core.c
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <elf32.h>
+#include <elf64.h>
+#include <kernel/cache_helpers.h>
+#include <mm/core_mmu.h>
+#include <pas_auth_core.h>
+#include <platform_pas.h>
+#include <string.h>
+#include <string_ext.h>
+#include <tee/tee_cryp_utl.h>
+#include <trace.h>
+#include <utee_defines.h>
+#include <util.h>
+
+#include "pas_subsys.h"
+
+/* Bounds check in u64 to avoid narrowing 64-bit ELF fields. */
+static bool check_range(uint64_t off, uint64_t len, uint64_t total)
+{
+	uint64_t end = 0;
+
+	if (ADD_OVERFLOW(off, len, &end))
+		return false;
+
+	return end <= total;
+}
+
+#define MI_PBT_PAGE_MODE_MASK		0x00100000
+#define MI_PBT_PAGE_MODE_SHIFT		20
+#define MI_PBT_ACCESS_TYPE_MASK		0x00E00000
+#define MI_PBT_ACCESS_TYPE_SHIFT	21
+#define MI_PBT_SEGMENT_TYPE_MASK	0x07000000
+#define MI_PBT_SEGMENT_TYPE_SHIFT	24
+
+#define MI_PBT_NON_PAGED_SEGMENT	0x0
+#define MI_PBT_HASH_SEGMENT		0x2
+/*
+ * NOTUSED/SHARED are access-type field values (not segment-type values); the
+ * MI_PBT_*_SEGMENT naming preserves the wire-format identifier names.
+ */
+#define MI_PBT_NOTUSED_SEGMENT		0x3
+#define MI_PBT_SHARED_SEGMENT		0x4
+
+#define MI_PBT_PAGE_MODE(x) \
+	(((x) & MI_PBT_PAGE_MODE_MASK) >> MI_PBT_PAGE_MODE_SHIFT)
+#define MI_PBT_ACCESS_TYPE(x) \
+	(((x) & MI_PBT_ACCESS_TYPE_MASK) >> MI_PBT_ACCESS_TYPE_SHIFT)
+#define MI_PBT_SEGMENT_TYPE(x) \
+	(((x) & MI_PBT_SEGMENT_TYPE_MASK) >> MI_PBT_SEGMENT_TYPE_SHIFT)
+
+static bool is_hashed(uint32_t p_type, uint32_t p_flags)
+{
+	if (p_type != PT_LOAD)
+		return false;
+
+	return MI_PBT_PAGE_MODE(p_flags) == MI_PBT_NON_PAGED_SEGMENT &&
+	       MI_PBT_SEGMENT_TYPE(p_flags) != MI_PBT_HASH_SEGMENT &&
+	       MI_PBT_ACCESS_TYPE(p_flags) != MI_PBT_NOTUSED_SEGMENT &&
+	       MI_PBT_ACCESS_TYPE(p_flags) != MI_PBT_SHARED_SEGMENT;
+}
+
+struct elf_info {
+	size_t ehsize;
+	size_t phoff;
+	size_t phentsize;
+	size_t phnum;
+	bool is_64;
+};
+
+static TEE_Result parse_elf(const uint8_t *fw, size_t fw_size,
+			    struct elf_info *info)
+{
+	const unsigned char *ident = fw;
+	size_t ehdr_size = 0;
+	size_t phent_size = 0;
+
+	if (fw_size < EI_NIDENT)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ident[EI_MAG0] != ELFMAG0 || ident[EI_MAG1] != ELFMAG1 ||
+	    ident[EI_MAG2] != ELFMAG2 || ident[EI_MAG3] != ELFMAG3)
+		return TEE_ERROR_BAD_FORMAT;
+
+	switch (ident[EI_CLASS]) {
+	case ELFCLASS64:
+		info->is_64 = true;
+		ehdr_size = sizeof(Elf64_Ehdr);
+		phent_size = sizeof(Elf64_Phdr);
+		break;
+	case ELFCLASS32:
+		info->is_64 = false;
+		ehdr_size = sizeof(Elf32_Ehdr);
+		phent_size = sizeof(Elf32_Phdr);
+		break;
+	default:
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	if (fw_size < ehdr_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (info->is_64) {
+		const Elf64_Ehdr *ehdr = (const void *)fw;
+
+		info->ehsize = ehdr->e_ehsize;
+		info->phoff = ehdr->e_phoff;
+		info->phentsize = ehdr->e_phentsize;
+		info->phnum = ehdr->e_phnum;
+	} else {
+		const Elf32_Ehdr *ehdr = (const void *)fw;
+
+		info->ehsize = ehdr->e_ehsize;
+		info->phoff = ehdr->e_phoff;
+		info->phentsize = ehdr->e_phentsize;
+		info->phnum = ehdr->e_phnum;
+	}
+
+	/*
+	 * A signer that shrinks e_ehsize below the class's real Ehdr size
+	 * would make verify_elf_header() hash fewer bytes than an unmodified
+	 * image, silently narrowing entry-0 coverage. Reject up front.
+	 */
+	if (info->ehsize < ehdr_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (info->phentsize < phent_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	return TEE_SUCCESS;
+}
+
+static void get_phdr(const uint8_t *fw, const struct elf_info *info,
+		     size_t idx, uint32_t *p_type, uint32_t *p_flags,
+		     uint64_t *p_paddr, size_t *p_filesz, size_t *p_memsz)
+{
+	const uint8_t *p = fw + info->phoff + idx * info->phentsize;
+
+	if (info->is_64) {
+		const Elf64_Phdr *phdr = (const void *)p;
+
+		*p_type = phdr->p_type;
+		*p_flags = phdr->p_flags;
+		*p_paddr = phdr->p_paddr;
+		*p_filesz = phdr->p_filesz;
+		*p_memsz = phdr->p_memsz;
+	} else {
+		const Elf32_Phdr *phdr = (const void *)p;
+
+		*p_type = phdr->p_type;
+		*p_flags = phdr->p_flags;
+		*p_paddr = phdr->p_paddr;
+		*p_filesz = phdr->p_filesz;
+		*p_memsz = phdr->p_memsz;
+	}
+}
+
+/* min(paddr) over the hashed-segment set. */
+static uint64_t reloc_base(const uint8_t *fw, const struct elf_info *info)
+{
+	uint64_t min_paddr = UINT64_MAX;
+	uint64_t paddr = 0;
+	uint32_t flags = 0;
+	uint32_t type = 0;
+	size_t file_len = 0;
+	size_t mem_len = 0;
+	size_t i = 0;
+
+	for (i = 0; i < info->phnum; i++) {
+		get_phdr(fw, info, i, &type, &flags, &paddr, &file_len,
+			 &mem_len);
+
+		if (!is_hashed(type, flags) || !file_len)
+			continue;
+
+		if (paddr < min_paddr)
+			min_paddr = paddr;
+	}
+
+	return min_paddr;
+}
+
+static TEE_Result hash_verify(uint32_t algo, const uint8_t *data,
+			      size_t data_len, const uint8_t *expected,
+			      size_t hash_size)
+{
+	uint8_t dgst[PAS_AUTH_CORE_MAX_HASH_SIZE] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (hash_size > sizeof(dgst))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = tee_hash_createdigest(algo, data, data_len, dgst, hash_size);
+	if (res)
+		return res;
+
+	if (consttime_memcmp(dgst, expected, hash_size))
+		res = TEE_ERROR_SECURITY;
+	else
+		res = TEE_SUCCESS;
+
+	memzero_explicit(dgst, sizeof(dgst));
+
+	return res;
+}
+
+static TEE_Result verify_elf_header(const struct pas_auth_core_ctx *ctx,
+				    const struct elf_info *info)
+{
+	size_t hdr_len = 0;
+
+	if (MUL_OVERFLOW(info->phentsize, info->phnum, &hdr_len))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ADD_OVERFLOW(hdr_len, info->ehsize, &hdr_len))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (hdr_len > ctx->metadata_len)
+		return TEE_ERROR_BAD_FORMAT;
+
+	return hash_verify(ctx->hash_algo, ctx->metadata, hdr_len,
+			   ctx->hash_table, ctx->hash_size);
+}
+
+TEE_Result pas_auth_core_verify_segments(const struct pas_auth_core_ctx *ctx)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	const uint8_t *expected = NULL;
+	struct elf_info info = { };
+	size_t phtab_size = 0;
+	uint64_t paddr = 0;
+	uint32_t flags = 0;
+	uint64_t offset = 0;
+	uint32_t type = 0;
+	size_t file_len = 0;
+	size_t mem_len = 0;
+	size_t verified = 0;
+	uint64_t base = 0;
+	size_t i = 0;
+
+	if (!ctx || !ctx->hash_table || !ctx->fw || !ctx->metadata)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!ctx->hash_size || ctx->hash_size > PAS_AUTH_CORE_MAX_HASH_SIZE)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	/*
+	 * Parse the ELF from the metadata blob (ELF header + phdrs + hash seg),
+	 * NOT from the carveout. The carveout holds only the loaded segments;
+	 * the ELF header is not present there.
+	 */
+	res = parse_elf(ctx->metadata, ctx->metadata_len, &info);
+	if (res)
+		return res;
+
+	if (MUL_OVERFLOW(info.phentsize, info.phnum, &phtab_size) ||
+	    !check_range(info.phoff, phtab_size, ctx->metadata_len))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ctx->num_entries != info.phnum)
+		return TEE_ERROR_SECURITY;
+
+	res = verify_elf_header(ctx, &info);
+	if (res) {
+		EMSG("PAS auth: ELF header hash mismatch");
+		return res;
+	}
+
+	/*
+	 * UINT64_MAX when no hashed segments; harmless since the loop below
+	 * skips non-hashed entries and the post-loop "verified" check rejects
+	 * a zero-segment image.
+	 */
+	base = reloc_base(ctx->metadata, &info);
+
+	for (i = 0; i < info.phnum; i++) {
+		get_phdr(ctx->metadata, &info, i, &type, &flags, &paddr,
+			 &file_len, &mem_len);
+
+		if (!is_hashed(type, flags) || !file_len)
+			continue;
+
+		if (paddr < base)
+			return TEE_ERROR_BAD_FORMAT;
+		offset = paddr - base;
+
+		if (!check_range(offset, file_len, ctx->fw_size))
+			return TEE_ERROR_BAD_FORMAT;
+
+		/*
+		 * A segment's [file_len, mem_len) ZI tail must be inside the
+		 * carveout and zeroed before hashing so stale REE bytes cannot
+		 * slip past the digest or run as uninitialized data.
+		 * mem_len < file_len is malformed.
+		 */
+		if (mem_len < file_len)
+			return TEE_ERROR_BAD_FORMAT;
+		if (!check_range(offset, mem_len, ctx->fw_size))
+			return TEE_ERROR_BAD_FORMAT;
+		if (mem_len > file_len) {
+			void *zi = ctx->fw + offset + file_len;
+			size_t zi_len = mem_len - file_len;
+
+			memset(zi, 0, zi_len);
+
+			/*
+			 * This range is mapped cached here, but the REE maps
+			 * the same carveout uncached and the DSP fetches it
+			 * outside the CPU's coherency domain. Unmapping does
+			 * no cache maintenance, so without an explicit flush
+			 * these zeros could sit dirty in cache and reach DDR
+			 * only after AUTH_AND_RESET released the DSP, which
+			 * would clobber live DSP state. Clean+invalidate
+			 * synchronously instead.
+			 */
+			dcache_cleaninv_range(zi, zi_len);
+		}
+
+		expected = ctx->hash_table + i * ctx->hash_size;
+
+		res = hash_verify(ctx->hash_algo, ctx->fw + offset, file_len,
+				  expected, ctx->hash_size);
+		if (res) {
+			EMSG("PAS auth: segment %zu hash mismatch", i);
+			return res;
+		}
+
+		verified++;
+	}
+
+	/* Entry 0 alone is not enough: some loadable segment must be hashed. */
+	if (!verified) {
+		EMSG("PAS auth: no loadable segments were hashed");
+		return TEE_ERROR_SECURITY;
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_platform_verify_image(uint32_t pas_id,
+				     const struct pas_fw_region *fw,
+				     const struct pas_metadata *metadata,
+				     const struct pas_hash_table *hash)
+{
+	struct qcom_pas_subsys *subsys = pas_lookup(pas_id);
+	struct pas_auth_core_ctx ctx = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct qcom_pas_data *data = NULL;
+	void *fw_va = NULL;
+	uint32_t fw_size = 0;
+
+	if (!subsys)
+		return TEE_ERROR_NOT_SUPPORTED;
+
+	if (!metadata->data || !metadata->size || !hash->table ||
+	    !hash->len || !fw->size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!hash->entry_size || hash->len % hash->entry_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	data = &subsys->data;
+
+	/*
+	 * MEM_SETUP must run first: it caches the platform-validated
+	 * (fw_base, fw_size). Without it, an REE-supplied fw_base is
+	 * unverified and could aim the hash check at attacker-chosen memory.
+	 */
+	if (!data->fw_base || !data->fw_size) {
+		EMSG("PAS auth: no MEM_SETUP for pas_id=%"PRIu32, pas_id);
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	if (fw->base != data->fw_base) {
+		EMSG("PAS auth: base %#"PRIxPA" != MEM_SETUP %#"PRIxPA,
+		     fw->base, data->fw_base);
+		return TEE_ERROR_SECURITY;
+	}
+	fw_size = data->fw_size; /* use image span for verification */
+
+	fw_va = core_mmu_add_mapping(MEM_AREA_RAM_NSEC, fw->base, fw_size);
+	if (!fw_va) {
+		EMSG("PAS auth: can't map carveout %#"PRIxPA"/%#"PRIx32,
+		     fw->base, fw_size);
+		return TEE_ERROR_GENERIC;
+	}
+
+	switch (hash->entry_size) {
+	case TEE_SHA256_HASH_SIZE:
+		ctx.hash_algo = TEE_ALG_SHA256;
+		break;
+	case TEE_SHA384_HASH_SIZE:
+		ctx.hash_algo = TEE_ALG_SHA384;
+		break;
+	default:
+		res = TEE_ERROR_NOT_SUPPORTED;
+		goto out;
+	}
+
+	ctx.hash_size = hash->entry_size;
+	ctx.hash_table = hash->table;
+	ctx.num_entries = hash->len / hash->entry_size;
+	ctx.metadata = metadata->data;
+	ctx.metadata_len = metadata->size;
+	ctx.fw = fw_va;
+	ctx.fw_size = fw_size;
+
+	res = pas_auth_core_verify_segments(&ctx);
+out:
+	if (core_mmu_remove_mapping(MEM_AREA_RAM_NSEC, fw_va, fw_size))
+		EMSG("PAS auth: failed to unmap carveout");
+
+	return res;
+}

--- a/core/pta/qcom/pas/pas_auth_core.h
+++ b/core/pta/qcom/pas/pas_auth_core.h
@@ -18,7 +18,7 @@
  * struct pas_auth_core_ctx - per-segment hash verification context
  * @hash_algo:      TEE_ALG_SHA256 or TEE_ALG_SHA384
  * @hash_size:      digest size in bytes (32 or 48)
- * @hash_table:     per-segment digest table, one entry per program header
+ * @hash_table:     authenticated digest table, one entry per program header
  * @num_entries:    number of digests; must equal e_phnum
  * @metadata:       raw MBN metadata blob: ELF header + phdrs + hash segment;
  *                  used for ELF parsing and entry-0 hash (NOT loaded into fw)

--- a/core/pta/qcom/pas/pas_auth_core.h
+++ b/core/pta/qcom/pas/pas_auth_core.h
@@ -1,0 +1,56 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_AUTH_CORE_H
+#define __PAS_AUTH_CORE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
+
+/* Maximum digest size handled (SHA-384). */
+#define PAS_AUTH_CORE_MAX_HASH_SIZE	48U
+
+/*
+ * struct pas_auth_core_ctx - per-segment hash verification context
+ * @hash_algo:      TEE_ALG_SHA256 or TEE_ALG_SHA384
+ * @hash_size:      digest size in bytes (32 or 48)
+ * @hash_table:     per-segment digest table, one entry per program header
+ * @num_entries:    number of digests; must equal e_phnum
+ * @metadata:       raw MBN metadata blob: ELF header + phdrs + hash segment;
+ *                  used for ELF parsing and entry-0 hash (NOT loaded into fw)
+ * @metadata_len:  size of @metadata in bytes
+ * @fw:             mapped base of the loaded firmware carveout; writable
+ *                  since the verifier zero-fills each segment's ZI tail
+ * @fw_size:        size of the carveout mapping in bytes
+ */
+struct pas_auth_core_ctx {
+	uint32_t hash_algo;
+	uint32_t hash_size;
+	const uint8_t *hash_table;
+	uint32_t num_entries;
+	const uint8_t *metadata;
+	size_t metadata_len;
+	uint8_t *fw;
+	size_t fw_size;
+};
+
+/*
+ * pas_auth_core_verify_segments() - verify loaded image against hash table
+ * @ctx: integrity-check context
+ *
+ * Verifies entry 0 (ELF header + phdr table from @ctx->metadata) and each
+ * loadable hashed segment at its loaded carveout offset (p_paddr - reloc_base).
+ * A segment whose p_memsz exceeds p_filesz carries a zero-init (ZI) tail that
+ * is not present in the loaded file bytes; its [filesz, memsz) range is bounds-
+ * checked against the carveout and zero-filled before hashing. Fails closed
+ * on first mismatch.
+ *
+ * Return TEE_SUCCESS, TEE_ERROR_SECURITY on mismatch, or an error on bad input.
+ */
+TEE_Result pas_auth_core_verify_segments(const struct pas_auth_core_ctx *ctx);
+
+#endif /* __PAS_AUTH_CORE_H */

--- a/core/pta/qcom/pas/pas_core.c
+++ b/core/pta/qcom/pas/pas_core.c
@@ -4,7 +4,6 @@
  */
 
 #include <drivers/clk_qcom.h>
-#include <mm/core_memprot.h>
 #include <mm/core_mmu.h>
 #include <platform_pas.h>
 #include <trace.h>
@@ -12,7 +11,7 @@
 
 #include "pas_subsys.h"
 
-static struct qcom_pas_subsys *pas_lookup(uint32_t pas_id)
+struct qcom_pas_subsys *pas_lookup(uint32_t pas_id)
 {
 	struct qcom_pas_subsys *subsys = NULL;
 	size_t count = 0;
@@ -61,7 +60,6 @@ TEE_Result pas_platform_mem_setup(uint32_t pas_id, uint32_t fw_size,
 	data->fw_base = fw_base_low;
 	data->fw_base |= SHIFT_U64(fw_base_high, 32);
 
-	/* Map the controller */
 	if (!data->base.va) {
 		data->base.va = (vaddr_t)core_mmu_add_mapping(MEM_AREA_IO_NSEC,
 							      data->base.pa,
@@ -125,10 +123,8 @@ TEE_Result pas_platform_auth_and_reset(uint32_t pas_id)
 		return qcom_clock_enable_pas_processor(data->clk_group);
 	case QCOM_PAS_RESET_CLK_ENABLE:
 		res = qcom_clock_enable(data->clk_group);
-		if (res != TEE_SUCCESS) {
-			EMSG("Failed to enable clocks: %d", res);
+		if (res != TEE_SUCCESS)
 			return res;
-		}
 
 		return subsys->ops->fw_start(data);
 	case QCOM_PAS_RESET_NONE:
@@ -141,9 +137,22 @@ TEE_Result pas_platform_auth_and_reset(uint32_t pas_id)
 TEE_Result pas_platform_shutdown(uint32_t pas_id)
 {
 	struct qcom_pas_subsys *subsys = pas_lookup(pas_id);
+	TEE_Result res = TEE_ERROR_GENERIC;
 
 	if (!subsys || !subsys->ops->fw_shutdown)
 		return TEE_ERROR_NOT_SUPPORTED;
 
-	return subsys->ops->fw_shutdown(&subsys->data);
+	res = subsys->ops->fw_shutdown(&subsys->data);
+	if (!res) {
+		/*
+		 * Drop the cached carveout coordinates so a subsequent load of
+		 * the same subsystem must call MEM_SETUP first: VERIFY_IMAGE
+		 * cross-checks its fw_base argument against these fields and
+		 * would otherwise accept stale values.
+		 */
+		subsys->data.fw_base = 0;
+		subsys->data.fw_size = 0;
+	}
+
+	return res;
 }

--- a/core/pta/qcom/pas/platform/pas_subsys.h
+++ b/core/pta/qcom/pas/platform/pas_subsys.h
@@ -77,4 +77,10 @@ struct qcom_pas_subsys {
  */
 struct qcom_pas_subsys *qcom_pas_platform_subsys(size_t *count);
 
+/*
+ * pas_lookup() : find the subsystem entry matching @pas_id in the platform's
+ * subsystem table, or NULL if unknown.
+ */
+struct qcom_pas_subsys *pas_lookup(uint32_t pas_id);
+
 #endif /* PAS_SUBSYS_H */

--- a/core/pta/qcom/pas/platform/platform_pas.h
+++ b/core/pta/qcom/pas/platform/platform_pas.h
@@ -44,8 +44,8 @@ struct pas_metadata {
 };
 
 /*
- * struct pas_hash_table - per-segment digest table, one entry per program
- * header. Supplied by the caller and not authenticated here.
+ * struct pas_hash_table - authenticated per-segment digest table, one entry
+ * per program header.
  * @table:      digest table
  * @len:        size of @table in bytes
  * @entry_size: digest size in bytes (32 for SHA-256, 48 for SHA-384)
@@ -57,12 +57,10 @@ struct pas_hash_table {
 };
 
 /*
- * Verify the integrity of a loaded firmware image against @hash. Maps
- * @fw, recomputes each segment digest and compares it to the table, then
- * unmaps.
- *
- * TODO: authenticating the hash table itself (certificate chain and
- * signature) will be added incrementally.
+ * Verify the integrity of a loaded firmware image against an authenticated
+ * @hash. Maps @fw, recomputes each segment digest and compares it to the
+ * table, then unmaps. The table must have already been authenticated
+ * (signature-verified) by the caller.
  */
 #ifdef CFG_QCOM_PAS_AUTH
 TEE_Result pas_platform_verify_image(uint32_t pas_id,

--- a/core/pta/qcom/pas/platform/platform_pas.h
+++ b/core/pta/qcom/pas/platform/platform_pas.h
@@ -7,6 +7,8 @@
 #define PLATFORM_PAS_H
 
 #include <resource_table.h>
+#include <tee_api_types.h>
+#include <types_ext.h>
 
 TEE_Result pas_platform_mem_setup(uint32_t pas_id, uint32_t fw_size,
 				  uint32_t fw_base_low, uint32_t fw_base_high);
@@ -19,5 +21,63 @@ TEE_Result pas_platform_is_supported(uint32_t pas_id);
 TEE_Result pas_platform_capabilities(uint32_t pas_id);
 TEE_Result pas_platform_init_image(uint32_t pas_id);
 TEE_Result pas_platform_shutdown(uint32_t pas_id);
+
+/*
+ * struct pas_fw_region - loaded firmware carveout
+ * @base: physical base address
+ * @size: size in bytes
+ */
+struct pas_fw_region {
+	paddr_t base;
+	uint32_t size;
+};
+
+/*
+ * struct pas_metadata - ELF metadata blob (header + phdrs)
+ * @data: used for ELF parsing and the ELF header hash (entry 0); NOT in
+ *        the firmware carveout
+ * @size: size of @data in bytes
+ */
+struct pas_metadata {
+	const uint8_t *data;
+	size_t size;
+};
+
+/*
+ * struct pas_hash_table - per-segment digest table, one entry per program
+ * header. Supplied by the caller and not authenticated here.
+ * @table:      digest table
+ * @len:        size of @table in bytes
+ * @entry_size: digest size in bytes (32 for SHA-256, 48 for SHA-384)
+ */
+struct pas_hash_table {
+	const uint8_t *table;
+	size_t len;
+	uint32_t entry_size;
+};
+
+/*
+ * Verify the integrity of a loaded firmware image against @hash. Maps
+ * @fw, recomputes each segment digest and compares it to the table, then
+ * unmaps.
+ *
+ * TODO: authenticating the hash table itself (certificate chain and
+ * signature) will be added incrementally.
+ */
+#ifdef CFG_QCOM_PAS_AUTH
+TEE_Result pas_platform_verify_image(uint32_t pas_id,
+				     const struct pas_fw_region *fw,
+				     const struct pas_metadata *metadata,
+				     const struct pas_hash_table *hash);
+#else
+static inline TEE_Result
+pas_platform_verify_image(uint32_t pas_id __unused,
+			  const struct pas_fw_region *fw __unused,
+			  const struct pas_metadata *metadata __unused,
+			  const struct pas_hash_table *hash __unused)
+{
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+#endif /* CFG_QCOM_PAS_AUTH */
 
 #endif

--- a/core/pta/qcom/pas/pta_qcom_pas.c
+++ b/core/pta/qcom/pas/pta_qcom_pas.c
@@ -3,13 +3,12 @@
  * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
-#include <initcall.h>
 #include <kernel/pseudo_ta.h>
-#include <kernel/user_ta.h>
-#include <platform_config.h>
+#include <kernel/ts_manager.h>
 #include <platform_pas.h>
 #include <pta_qcom_pas.h>
 #include <string.h>
+#include <util.h>
 
 #define PTA_NAME	"pta.qcom.pas"
 
@@ -26,7 +25,6 @@ static TEE_Result qcom_pas_is_supported(uint32_t pt,
 
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
-	DMSG("invoked with pas_id: %d", params[0].value.a);
 
 	return pas_platform_is_supported(params[0].value.a);
 }
@@ -41,11 +39,9 @@ static TEE_Result qcom_pas_capabilities(uint32_t pt,
 
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
-	DMSG("invoked with pas_id: %d", params[0].value.a);
 
-	/* Capabilities flags reserved for future use */
 	params[1].value.a = 0;
-	return pas_platform_capabilities(params[1].value.a);
+	return pas_platform_capabilities(params[0].value.a);
 }
 
 static TEE_Result qcom_pas_init_image(uint32_t pt,
@@ -58,7 +54,6 @@ static TEE_Result qcom_pas_init_image(uint32_t pt,
 
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
-	DMSG("invoked with pas_id: %d", params[0].value.a);
 
 	return pas_platform_init_image(params[0].value.a);
 }
@@ -72,7 +67,6 @@ static TEE_Result qcom_pas_mem_setup(uint32_t pt,
 						TEE_PARAM_TYPE_NONE);
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
-	DMSG("invoked with pas_id: %d", params[0].value.a);
 
 	return pas_platform_mem_setup(params[0].value.a, params[0].value.b,
 				      params[1].value.a, params[1].value.b);
@@ -88,7 +82,6 @@ static TEE_Result qcom_pas_get_resource_table(uint32_t pt,
 
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
-	DMSG("invoked with pas_id: %d", params[0].value.a);
 
 	return pas_platform_get_resource_table(params[0].value.a,
 					       params[1].memref.buffer,
@@ -106,7 +99,6 @@ qcom_pas_set_remote_state(uint32_t pt,
 
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
-	DMSG("invoked with pas_id: %d", params[0].value.a);
 
 	return pas_platform_set_remote_state(params[0].value.a,
 					     params[0].value.b);
@@ -122,7 +114,6 @@ static TEE_Result qcom_pas_auth_and_reset(uint32_t pt,
 
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
-	DMSG("invoked with pas_id: %d", params[0].value.a);
 
 	return pas_platform_auth_and_reset(params[0].value.a);
 }
@@ -138,7 +129,6 @@ qcom_pas_shutdown(uint32_t pt,
 
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
-	DMSG("invoked with pas_id: %d", params[0].value.a);
 
 	return pas_platform_shutdown(params[0].value.a);
 }
@@ -170,9 +160,6 @@ static TEE_Result pta_qcom_pas_invoke_command(void *session __unused,
 	}
 }
 
-/*
- * Pseudo Trusted Application entry points
- */
 static TEE_Result
 pta_qcom_pas_open_session(uint32_t pt __unused,
 			  TEE_Param params[TEE_NUM_PARAMS] __unused,

--- a/core/pta/qcom/pas/pta_qcom_pas.c
+++ b/core/pta/qcom/pas/pta_qcom_pas.c
@@ -89,8 +89,7 @@ static TEE_Result qcom_pas_get_resource_table(uint32_t pt,
 }
 
 static TEE_Result
-qcom_pas_set_remote_state(uint32_t pt,
-			  TEE_Param params[TEE_NUM_PARAMS]__maybe_unused)
+qcom_pas_set_remote_state(uint32_t pt, TEE_Param params[TEE_NUM_PARAMS])
 {
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 						TEE_PARAM_TYPE_NONE,
@@ -119,8 +118,7 @@ static TEE_Result qcom_pas_auth_and_reset(uint32_t pt,
 }
 
 static TEE_Result
-qcom_pas_shutdown(uint32_t pt,
-		  TEE_Param params[TEE_NUM_PARAMS] __maybe_unused)
+qcom_pas_shutdown(uint32_t pt, TEE_Param params[TEE_NUM_PARAMS])
 {
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 						TEE_PARAM_TYPE_NONE,
@@ -131,6 +129,46 @@ qcom_pas_shutdown(uint32_t pt,
 		return TEE_ERROR_BAD_PARAMETERS;
 
 	return pas_platform_shutdown(params[0].value.a);
+}
+
+static TEE_Result
+qcom_pas_verify_image(uint32_t pt, TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						TEE_PARAM_TYPE_VALUE_INPUT,
+						TEE_PARAM_TYPE_MEMREF_INPUT,
+						TEE_PARAM_TYPE_VALUE_INPUT);
+	/*
+	 * params[2].memref: packed [metadata | hash_table] buffer
+	 * params[3].value.a: hash_size
+	 * params[3].value.b: metadata_len (= offset of hash_table in buf)
+	 */
+	struct pas_hash_table hash = { };
+	struct pas_metadata metadata = { };
+	struct pas_fw_region fw = { };
+	const uint8_t *buf = NULL;
+
+	if (pt != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!params[2].memref.buffer || !params[2].memref.size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	metadata.size = params[3].value.b;
+	if (!metadata.size || metadata.size >= params[2].memref.size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	buf = params[2].memref.buffer;
+	metadata.data = buf;
+	hash.table = buf + metadata.size;
+	hash.len = params[2].memref.size - metadata.size;
+	hash.entry_size = params[3].value.a;
+
+	fw.base = reg_pair_to_64(params[1].value.b, params[1].value.a);
+	fw.size = params[0].value.b;
+
+	return pas_platform_verify_image(params[0].value.a, &fw, &metadata,
+					 &hash);
 }
 
 static TEE_Result pta_qcom_pas_invoke_command(void *session __unused,
@@ -155,6 +193,8 @@ static TEE_Result pta_qcom_pas_invoke_command(void *session __unused,
 		return qcom_pas_set_remote_state(param_types, params);
 	case PTA_QCOM_PAS_SHUTDOWN:
 		return qcom_pas_shutdown(param_types, params);
+	case PTA_QCOM_PAS_VERIFY_IMAGE:
+		return qcom_pas_verify_image(param_types, params);
 	default:
 		return TEE_ERROR_NOT_IMPLEMENTED;
 	}

--- a/core/pta/qcom/pas/sub.mk
+++ b/core/pta/qcom/pas/sub.mk
@@ -1,5 +1,6 @@
 srcs-y += pta_qcom_pas.c
 srcs-y += pas_core.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth_core.c
 incdirs-y += .
 incdirs-y += platform/
 subdirs-y += platform/$(PLATFORM_FLAVOR)

--- a/core/pta/qcom/sub.mk
+++ b/core/pta/qcom/sub.mk
@@ -1,1 +1,5 @@
 subdirs-$(CFG_QCOM_PAS_PTA) += pas
+
+# Exposes qfprom-backed fuse reads to user TAs.
+CFG_QCOM_FUSE_PTA ?= n
+subdirs-$(CFG_QCOM_FUSE_PTA) += fuse

--- a/lib/libutee/include/pta_qcom_fuse.h
+++ b/lib/libutee/include/pta_qcom_fuse.h
@@ -1,0 +1,89 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PTA_QCOM_FUSE_H
+#define __PTA_QCOM_FUSE_H
+
+/*
+ * Interface to the pseudo TA which exposes Qualcomm fuse (QFPROM) state to
+ * user-mode TAs that cannot access the QFPROM core driver directly.
+ */
+
+#define PTA_QCOM_FUSE_UUID { 0x6b46384c, 0x4a3e, 0x4b9d, \
+		{ 0xa8, 0x2f, 0x1c, 0x3d, 0xe5, 0x9f, 0xa2, 0x11 } }
+
+/*
+ * Query whether secure boot (image authentication) is enabled.
+ *
+ * Reads the SECURE_BOOTn AUTH_EN bit for the APPS code segment.
+ *
+ * [out] params[0].value.a:  1 if secure boot is enabled, 0 otherwise
+ */
+#define PTA_QCOM_FUSE_GET_SECBOOT_STATE		1
+
+/* Size of the OEM root-of-trust digest (SHA-384) returned below. */
+#define PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE	48
+
+/*
+ * Read the OEM root-of-trust digest from the PK_HASH_0 fuse region.
+ *
+ * [out] params[0].memref:  buffer receiving the digest; must be at least
+ *                          PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE bytes
+ */
+#define PTA_QCOM_FUSE_GET_ROOT_OF_TRUST		2
+
+/*
+ * Read the device-identity fields used for metadata binding.
+ *
+ * [out] params[0].value.a:  OEM_ID
+ * [out] params[0].value.b:  MODEL_ID
+ * [out] params[1].value.a:  JTAG_ID (authentication bits, masked 0x0FFFFFFF)
+ * [out] params[1].value.b:  serial number
+ */
+#define PTA_QCOM_FUSE_GET_DEVICE_IDS		3
+
+/*
+ * Read the SOC hardware version family|device field (bits 31:16 of the TCSR
+ * SOC_HW_VERSION register), matching the metadata soc_vers binding value.
+ *
+ * [out] params[0].value.a:  family|device number
+ */
+#define PTA_QCOM_FUSE_GET_SOC_HW_VERSION	4
+
+/*
+ * Read the per-segment hash digest size selected by a metadata root_cert_sel
+ * index.
+ *
+ * [in]  params[0].value.a:  root_cert_sel (0-3)
+ * [out] params[0].value.b:  digest size in bytes (32 = SHA-256, 48 = SHA-384)
+ */
+#define PTA_QCOM_FUSE_GET_SEGMENT_HASH_SIZE	5
+
+/*
+ * Query whether Extended Key Usage enforcement is fused on. When enabled,
+ * image certificate chains must carry the code-signing EKU OID on the leaf.
+ *
+ * [out] params[0].value.a:  1 if EKU enforcement is enabled, 0 otherwise
+ */
+#define PTA_QCOM_FUSE_GET_EKU_ENFORCEMENT_EN	6
+
+/*
+ * Query the APPS SECURE_BOOTn USE_SERIAL_NUM fuse override. When set,
+ * serial-number binding is forced regardless of the image metadata's own
+ * serial-number-binding flag.
+ *
+ * [out] params[0].value.a:  1 if the override is blown, 0 otherwise
+ */
+#define PTA_QCOM_FUSE_GET_USE_SERIAL_NUM	7
+
+/*
+ * Query whether OEM image encryption (UIE) is provisioned, i.e. whether the
+ * OEM_CONFIG0 IMAGE_ENCRYPTION_ENABLE fuse is blown.
+ *
+ * [out] params[0].value.a:  1 if image encryption is enabled, 0 otherwise
+ */
+#define PTA_QCOM_FUSE_GET_IMAGE_ENCRYPTION_EN	8
+
+#endif /* __PTA_QCOM_FUSE_H */

--- a/lib/libutee/include/pta_qcom_pas.h
+++ b/lib/libutee/include/pta_qcom_pas.h
@@ -84,4 +84,27 @@
  */
 #define PTA_QCOM_PAS_SHUTDOWN			8
 
-#endif /* __PTA_QCOM_REMOTEPROC_H */
+/*
+ * PAS firmware image integrity verification.
+ *
+ * Recomputes the per-segment digests of the firmware already loaded into its
+ * carveout and compares them to a caller-supplied hash table. The caller is
+ * responsible for ensuring the hash table is trusted (e.g. the PAS user TA
+ * performs metadata parsing and, when signature authentication is enabled,
+ * anchors the table to the fused root-of-trust before invoking this command).
+ *
+ * [in]  params[0].value.a:	Unique 32bit remote processor identifier
+ * [in]  params[0].value.b:	Firmware size
+ * [in]  params[1].value.a:	32bit LSB firmware memory address
+ * [in]  params[1].value.b:	32bit MSB firmware memory address
+ * [in]  params[2].memref:	Packed [metadata | hash_table] buffer: the
+ *				INIT_IMAGE metadata blob (ELF header + phdrs)
+ *				followed immediately by the per-segment
+ *				hash table (one digest per phdr)
+ * [in]  params[3].value.a:	Digest size in bytes (32=SHA-256, 48=SHA-384)
+ * [in]  params[3].value.b:	Metadata size, i.e. offset of hash_table
+ *				within params[2].memref
+ */
+#define PTA_QCOM_PAS_VERIFY_IMAGE		9
+
+#endif /* __PTA_QCOM_PAS_H */

--- a/ta/qcom_pas/include/pas_auth.h
+++ b/ta/qcom_pas/include/pas_auth.h
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_AUTH_H
+#define __PAS_AUTH_H
+
+#include <qcom_pas_priv.h>
+#include <tee_internal_api.h>
+
+/*
+ * Firmware integrity backend for the PAS TA.
+ *
+ * The REE drives two commands, and the checks are deliberately split between
+ * them:
+ *
+ *   INIT_IMAGE      - before the REE loads anything. Saves a TEE-private copy
+ *                     of the image metadata and locates the per-segment hash
+ *                     table inside it.
+ *   AUTH_AND_RESET  - after the REE has loaded the segments, before the
+ *                     peripheral leaves reset. Re-hashes each loaded segment
+ *                     and compares it against the table.
+ *
+ * Hashing after the load and before reset release is what closes the window
+ * in which the REE could alter the carveout behind the TEE's back.
+ *
+ * The hash table itself comes from REE-supplied metadata and is not
+ * authenticated.
+ *
+ * TODO: signature authentication of the hash table (certificate chain,
+ * signature, fuse-bound SW/HW binding and anti-rollback) will be added
+ * incrementally, at INIT_IMAGE, before the REE loads any segment.
+ */
+
+#ifdef CFG_QCOM_PAS_AUTH
+/*
+ * pas_auth_save_metadata() - save a private copy of the INIT_IMAGE metadata
+ * @s:      per-session context
+ * @pt:     INIT_IMAGE invocation parameter types
+ * @params: INIT_IMAGE invocation parameters; params[0].value.a is the
+ *          peripheral pas_id, params[1].memref is the ELF header +
+ *          program-header table + MBN hash segment
+ *
+ * Copies the metadata into TEE-private memory keyed by pas_id so the REE
+ * cannot alter it between INIT_IMAGE and AUTH_AND_RESET.
+ */
+TEE_Result pas_auth_save_metadata(struct qcom_pas_session *s, uint32_t pt,
+				  TEE_Param params[TEE_NUM_PARAMS]);
+
+/*
+ * pas_auth_authenticate() - locate the hash table in the saved metadata
+ * @s:      per-session context
+ * @pas_id: peripheral identifier the metadata belongs to
+ *
+ * Parses the MBN hash segment to find the per-segment hash table and marks
+ * the slot ready for pas_auth_verify_reset(). Call after the matching
+ * pas_auth_save_metadata() and the PTA INIT_IMAGE call.
+ */
+TEE_Result pas_auth_authenticate(struct qcom_pas_session *s, uint32_t pas_id);
+
+/*
+ * pas_auth_verify_reset() - re-verify loaded segments at AUTH_AND_RESET
+ * @s:           per-session context
+ * @pta_session: shared PAS PTA session handle
+ * @pas_id:      peripheral identifier the metadata belongs to
+ * @params:      AUTH_AND_RESET invocation parameters
+ *
+ * Packs the metadata and hash table into a single memref and hands it to
+ * the PAS PTA's VERIFY_IMAGE command, which re-hashes each loaded firmware
+ * segment against the per-segment hash table.
+ */
+TEE_Result pas_auth_verify_reset(struct qcom_pas_session *s,
+				 TEE_TASessionHandle pta_session,
+				 uint32_t pas_id,
+				 TEE_Param params[TEE_NUM_PARAMS]);
+#else
+static inline TEE_Result
+pas_auth_save_metadata(struct qcom_pas_session *s __unused,
+		       uint32_t pt __unused,
+		       TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	return TEE_SUCCESS;
+}
+
+static inline TEE_Result
+pas_auth_authenticate(struct qcom_pas_session *s __unused,
+		      uint32_t pas_id __unused)
+{
+	return TEE_SUCCESS;
+}
+
+static inline TEE_Result
+pas_auth_verify_reset(struct qcom_pas_session *s __unused,
+		      TEE_TASessionHandle pta_session __unused,
+		      uint32_t pas_id __unused,
+		      TEE_Param params[TEE_NUM_PARAMS] __unused)
+{
+	return TEE_SUCCESS;
+}
+#endif /* CFG_QCOM_PAS_AUTH */
+
+#endif /* __PAS_AUTH_H */

--- a/ta/qcom_pas/include/pas_auth.h
+++ b/ta/qcom_pas/include/pas_auth.h
@@ -10,27 +10,26 @@
 #include <tee_internal_api.h>
 
 /*
- * Firmware integrity backend for the PAS TA.
+ * Firmware authentication backend for the PAS TA.
  *
  * The REE drives two commands, and the checks are deliberately split between
  * them:
  *
  *   INIT_IMAGE      - before the REE loads anything. Saves a TEE-private copy
- *                     of the image metadata and locates the per-segment hash
- *                     table inside it.
+ *                     of the image metadata, locates the per-segment hash
+ *                     table inside it and, on devices with secure-boot fuses
+ *                     blown, authenticates that metadata: certificate chain,
+ *                     signature, fuse-bound SW/HW binding and anti-rollback.
  *   AUTH_AND_RESET  - after the REE has loaded the segments, before the
  *                     peripheral leaves reset. Re-hashes each loaded segment
  *                     and compares it against the table.
  *
- * Hashing after the load and before reset release is what closes the window
- * in which the REE could alter the carveout behind the TEE's back.
+ * Authenticating before the load and hashing after it is what closes the
+ * window in which the REE could alter the carveout behind the TEE's back.
  *
- * The hash table itself comes from REE-supplied metadata and is not
- * authenticated.
- *
- * TODO: signature authentication of the hash table (certificate chain,
- * signature, fuse-bound SW/HW binding and anti-rollback) will be added
- * incrementally, at INIT_IMAGE, before the REE loads any segment.
+ * Segment-hash verification always runs. Signature authentication is a
+ * runtime decision inside pas_auth_authenticate(), taken on the device's
+ * secure-boot fuse state; on unprovisioned devices it is skipped.
  */
 
 #ifdef CFG_QCOM_PAS_AUTH
@@ -49,12 +48,14 @@ TEE_Result pas_auth_save_metadata(struct qcom_pas_session *s, uint32_t pt,
 				  TEE_Param params[TEE_NUM_PARAMS]);
 
 /*
- * pas_auth_authenticate() - locate the hash table in the saved metadata
+ * pas_auth_authenticate() - authenticate the saved metadata for @pas_id
  * @s:      per-session context
  * @pas_id: peripheral identifier the metadata belongs to
  *
- * Parses the MBN hash segment to find the per-segment hash table and marks
- * the slot ready for pas_auth_verify_reset(). Call after the matching
+ * Parses the MBN hash segment into the per-segment hash table. On devices
+ * provisioned for secure boot this also verifies the certificate chain,
+ * signature, SW/HW bindings and anti-rollback version; on unprovisioned
+ * devices the signature step is skipped. Call after the matching
  * pas_auth_save_metadata() and the PTA INIT_IMAGE call.
  */
 TEE_Result pas_auth_authenticate(struct qcom_pas_session *s, uint32_t pas_id);
@@ -68,7 +69,7 @@ TEE_Result pas_auth_authenticate(struct qcom_pas_session *s, uint32_t pas_id);
  *
  * Packs the metadata and hash table into a single memref and hands it to
  * the PAS PTA's VERIFY_IMAGE command, which re-hashes each loaded firmware
- * segment against the per-segment hash table.
+ * segment against the authenticated table.
  */
 TEE_Result pas_auth_verify_reset(struct qcom_pas_session *s,
 				 TEE_TASessionHandle pta_session,

--- a/ta/qcom_pas/include/pas_fuse.h
+++ b/ta/qcom_pas/include/pas_fuse.h
@@ -1,0 +1,121 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_FUSE_H
+#define __PAS_FUSE_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * Thin wrappers around the fuse PTA (PTA_QCOM_FUSE_UUID). None apply policy
+ * to the result - that is qcom_pas_auth.c's job. Callers on a fuse PTA
+ * access failure decide for themselves whether that means "not enforced"
+ * or a hard error.
+ *
+ * All calls share one session held for the TA's lifetime (see pas_fuse_open()
+ * / pas_fuse_close()).
+ */
+
+/*
+ * pas_fuse_open() - open the shared fuse PTA session
+ *
+ * Call once from TA_OpenSessionEntryPoint, alongside opening the PAS PTA
+ * session. Every pas_fuse_* call below uses this session; none open their
+ * own.
+ */
+#ifdef CFG_QCOM_PAS_AUTH
+TEE_Result pas_fuse_open(void);
+
+/*
+ * pas_fuse_close() - close the shared fuse PTA session
+ *
+ * Call once from TA_CloseSessionEntryPoint, alongside closing the PAS PTA
+ * session.
+ */
+void pas_fuse_close(void);
+#else
+static inline TEE_Result pas_fuse_open(void)
+{
+	return TEE_SUCCESS;
+}
+
+static inline void pas_fuse_close(void)
+{
+}
+#endif /* CFG_QCOM_PAS_AUTH */
+
+/*
+ * pas_fuse_get_secboot_and_root_anchor() - secure-boot state + root-of-trust
+ * @anchor:     buffer to receive the OEM root-of-trust digest (SHA-384,
+ *              PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE bytes)
+ * @secboot_on: out: true if secure boot (image authentication) is fused on
+ */
+TEE_Result pas_fuse_get_secboot_and_root_anchor(uint8_t *anchor,
+						bool *secboot_on);
+
+/*
+ * struct pas_fuse_hw_binding_info - fuse-backed values for HW binding checks
+ * @oem_id:                OEM_ID fuse value
+ * @model_id:               MODEL_ID fuse value
+ * @jtag_id:                JTAG_ID authentication bits (masked 0x0FFFFFFF)
+ * @serial_num:             device serial number
+ * @use_serial_num_override: true if the APPS SECURE_BOOTn USE_SERIAL_NUM
+ *                            override fuse is blown (forces serial binding
+ *                            regardless of the image metadata's own flag)
+ * @soc_fam_dev:            SoC family|device number (TCSR SOC_HW_VERSION bits
+ *                            31:16), valid only when @need_soc_vers was set
+ */
+struct pas_fuse_hw_binding_info {
+	uint32_t oem_id;
+	uint32_t model_id;
+	uint32_t jtag_id;
+	uint32_t serial_num;
+	bool use_serial_num_override;
+	uint32_t soc_fam_dev;
+};
+
+/*
+ * pas_fuse_get_hw_binding_info() - read every fuse-backed HW-binding value
+ * @need_soc_vers: whether to also read SOC_HW_VERSION (only needed when the
+ *                 image metadata sets IN_USE_SOC_HW_VERSION); skipping it
+ *                 otherwise saves a command on the shared session
+ * @info:          out: fuse values, undefined on error
+ *
+ * Reads device ids, the serial-number override and (conditionally) the SoC
+ * version over one fuse PTA session, matching how the caller consumes them
+ * together for a single image's HW binding checks.
+ */
+TEE_Result pas_fuse_get_hw_binding_info(bool need_soc_vers,
+					struct pas_fuse_hw_binding_info *info);
+
+/*
+ * pas_fuse_get_eku_enforcement_en() - OEM_CONFIG2 EKU_ENFORCEMENT_EN
+ * @eku_enforced: out: true if the EKU code-signing OID is required
+ *
+ * Returns an error on a fuse PTA access failure rather than defaulting
+ * @eku_enforced to a fixed value. Fuse-read failures are fatal to the
+ * whole authentication attempt; callers must fail closed.
+ */
+TEE_Result pas_fuse_get_eku_enforcement_en(bool *eku_enforced);
+
+/*
+ * pas_fuse_get_image_encryption_en() - OEM_CONFIG0 IMAGE_ENCRYPTION_ENABLE
+ * Returns true (not false/error) on a fuse PTA access failure: an image
+ * carrying UIE parameters must never be silently accepted as plaintext when
+ * the device's encryption-fuse state cannot be confirmed.
+ */
+bool pas_fuse_get_image_encryption_en(void);
+
+/*
+ * pas_fuse_get_segment_hash_size() - per-segment digest size for root_cert_sel
+ * @root_cert_sel: metadata root_cert_sel index (0-3)
+ * @hash_size:     out: digest size in bytes (32 = SHA-256, 48 = SHA-384)
+ */
+TEE_Result pas_fuse_get_segment_hash_size(uint32_t root_cert_sel,
+					  uint32_t *hash_size);
+
+#endif /* __PAS_FUSE_H */

--- a/ta/qcom_pas/include/pas_mbn_parser.h
+++ b/ta/qcom_pas/include/pas_mbn_parser.h
@@ -29,9 +29,8 @@
  * Hash table: one digest per ELF program header; entry 0 = digest of the ELF
  * header plus program-header table, entry i = digest of the segment at phdr i.
  *
- * This file extracts the hash table. The OEM/QTI metadata, signature and
- * certificate regions are located and reported below, but nothing consumes
- * them yet.
+ * This file extracts the hash table; OEM/QTI metadata, signature and
+ * certificate regions are pas_meta.h's concern.
  */
 
 #define PAS_MBN_VERSION_5	5

--- a/ta/qcom_pas/include/pas_mbn_parser.h
+++ b/ta/qcom_pas/include/pas_mbn_parser.h
@@ -25,6 +25,15 @@
  *   v6 (48-byte header):
  *     [header][qti meta][oem meta][hash table]
  *     [qti sig][qti certs][oem sig][oem certs]
+ *   v7 (40-byte header):
+ *     [header][common meta][qti meta][oem meta][hash table]
+ *     [qti sig][qti certs][oem sig][oem certs]
+ *
+ * v7 adds a common-metadata block shared by both signers (holding the hash
+ * table's digest algorithm, among other fields) ahead of the per-signer
+ * metadata; its header uses a different field layout and offsets from v5/v6
+ * (see pas_mbn_parser_priv.h) but the same "fixed header, then concatenated
+ * variable-length regions" shape.
  *
  * Hash table: one digest per ELF program header; entry 0 = digest of the ELF
  * header plus program-header table, entry i = digest of the segment at phdr i.
@@ -35,26 +44,29 @@
 
 #define PAS_MBN_VERSION_5	5
 #define PAS_MBN_VERSION_6	6
+#define PAS_MBN_VERSION_7	7
 
 /*
  * struct pas_mbn - parsed view of an MBN hash segment
  *
  * All pointers reference the caller-owned metadata buffer.
  *
- * @version:		MBN header version (PAS_MBN_VERSION_5 / _6)
+ * @version:		MBN header version (PAS_MBN_VERSION_5 / _6 / _7)
  * @hash_table:		per-program-header digest table
  * @hash_table_size:	size of the hash table in bytes
  * @num_entries:	number of digests in the table
  * @hash_size:		digest size in bytes (32 = SHA-256, 48 = SHA-384)
  * @signed_region:	first byte covered by the signature
  * @signed_region_size:	number of bytes covered by the signature
- * @oem_meta:		OEM metadata block, NULL if absent (v6 only)
+ * @common_meta:	v7 common metadata block, NULL if absent (v7 only)
+ * @common_meta_size:	common metadata size in bytes
+ * @oem_meta:		OEM metadata block, NULL if absent (v6/v7 only)
  * @oem_meta_size:	OEM metadata size in bytes
  * @oem_sig:		OEM signature (NULL if absent)
  * @oem_sig_size:	OEM signature size
  * @oem_certs:		OEM certificate chain, DER, leaf first (NULL if absent)
  * @oem_certs_size:	OEM certificate chain size
- * @qti_meta:		QTI metadata block, NULL if absent (v6 only)
+ * @qti_meta:		QTI metadata block, NULL if absent (v6/v7 only)
  * @qti_meta_size:	QTI metadata size in bytes
  * @qti_sig:		QTI signature (NULL if not double-signed)
  * @qti_sig_size:	QTI signature size
@@ -62,6 +74,11 @@
  * @qti_certs_size:	QTI certificate chain size
  * @uie_encrypted:	true if the segment carries a UIE encryption parameter
  *			block (image content is encrypted)
+ *
+ * The common_meta/oem_meta/oem_sig/oem_certs, qti_meta/qti_sig/qti_certs and
+ * signed_region fields are populated by pas_mbn_parse() for pas_meta.c's
+ * use under CFG_QCOM_PAS_AUTH; a CFG_QCOM_PAS_AUTH-only
+ * build parses but never reads them.
  */
 struct pas_mbn {
 	uint32_t version;
@@ -73,6 +90,9 @@ struct pas_mbn {
 
 	const uint8_t *signed_region;
 	size_t signed_region_size;
+
+	const uint8_t *common_meta;
+	size_t common_meta_size;
 
 	const uint8_t *oem_meta;
 	size_t oem_meta_size;

--- a/ta/qcom_pas/include/pas_mbn_parser.h
+++ b/ta/qcom_pas/include/pas_mbn_parser.h
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_MBN_PARSER_H
+#define __PAS_MBN_PARSER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * Qualcomm MBN (Multiboot Binary) hash-segment parser.
+ *
+ * The INIT_IMAGE metadata blob is:
+ *   [ phdrs[0].p_filesz bytes ]  ELF header + program-header table
+ *   [ hash-segment bytes      ]  verbatim content of the MBN hash-segment phdr
+ *
+ * The MBN hash segment (at phdrs[0].p_filesz) holds signing material:
+ *
+ *   v5 (40-byte header):
+ *     [header][hash table][qti sig][qti certs][oem sig][oem certs]
+ *   v6 (48-byte header):
+ *     [header][qti meta][oem meta][hash table]
+ *     [qti sig][qti certs][oem sig][oem certs]
+ *
+ * Hash table: one digest per ELF program header; entry 0 = digest of the ELF
+ * header plus program-header table, entry i = digest of the segment at phdr i.
+ *
+ * This file extracts the hash table. The OEM/QTI metadata, signature and
+ * certificate regions are located and reported below, but nothing consumes
+ * them yet.
+ */
+
+#define PAS_MBN_VERSION_5	5
+#define PAS_MBN_VERSION_6	6
+
+/*
+ * struct pas_mbn - parsed view of an MBN hash segment
+ *
+ * All pointers reference the caller-owned metadata buffer.
+ *
+ * @version:		MBN header version (PAS_MBN_VERSION_5 / _6)
+ * @hash_table:		per-program-header digest table
+ * @hash_table_size:	size of the hash table in bytes
+ * @num_entries:	number of digests in the table
+ * @hash_size:		digest size in bytes (32 = SHA-256, 48 = SHA-384)
+ * @signed_region:	first byte covered by the signature
+ * @signed_region_size:	number of bytes covered by the signature
+ * @oem_meta:		OEM metadata block, NULL if absent (v6 only)
+ * @oem_meta_size:	OEM metadata size in bytes
+ * @oem_sig:		OEM signature (NULL if absent)
+ * @oem_sig_size:	OEM signature size
+ * @oem_certs:		OEM certificate chain, DER, leaf first (NULL if absent)
+ * @oem_certs_size:	OEM certificate chain size
+ * @qti_meta:		QTI metadata block, NULL if absent (v6 only)
+ * @qti_meta_size:	QTI metadata size in bytes
+ * @qti_sig:		QTI signature (NULL if not double-signed)
+ * @qti_sig_size:	QTI signature size
+ * @qti_certs:		QTI certificate chain (NULL if not double-signed)
+ * @qti_certs_size:	QTI certificate chain size
+ * @uie_encrypted:	true if the segment carries a UIE encryption parameter
+ *			block (image content is encrypted)
+ */
+struct pas_mbn {
+	uint32_t version;
+
+	const uint8_t *hash_table;
+	size_t hash_table_size;
+	uint32_t num_entries;
+	uint32_t hash_size;
+
+	const uint8_t *signed_region;
+	size_t signed_region_size;
+
+	const uint8_t *oem_meta;
+	size_t oem_meta_size;
+	const uint8_t *oem_sig;
+	size_t oem_sig_size;
+	const uint8_t *oem_certs;
+	size_t oem_certs_size;
+
+	const uint8_t *qti_meta;
+	size_t qti_meta_size;
+	const uint8_t *qti_sig;
+	size_t qti_sig_size;
+	const uint8_t *qti_certs;
+	size_t qti_certs_size;
+
+	bool uie_encrypted;
+};
+
+/*
+ * pas_mbn_parse() - parse the MBN hash segment inside an INIT_IMAGE blob
+ * @md:		INIT_IMAGE metadata blob (ELF preamble + hash segment)
+ * @md_size:	size of @md in bytes
+ * @hash_size:	expected digest size (32 or 48); used to derive entry count
+ * @out:	parsed result on success
+ *
+ * Return TEE_SUCCESS, TEE_ERROR_BAD_FORMAT, or TEE_ERROR_BAD_PARAMETERS.
+ */
+TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
+			 uint32_t hash_size, struct pas_mbn *out);
+
+#endif /* __PAS_MBN_PARSER_H */

--- a/ta/qcom_pas/include/pas_mbn_parser_priv.h
+++ b/ta/qcom_pas/include/pas_mbn_parser_priv.h
@@ -11,8 +11,9 @@
 #include <tee_api_types.h>
 
 /*
- * MBN hash-segment binary-format primitives, used by pas_mbn_parser.c for
- * segment location and hash-table extraction.
+ * MBN hash-segment binary-format primitives, shared between
+ * pas_mbn_parser.c (segment location + hash table) and pas_meta.c
+ * (OEM/QTI metadata, signature and certificate regions).
  */
 
 /* MBN header field offsets (bytes from hash-segment start) */

--- a/ta/qcom_pas/include/pas_mbn_parser_priv.h
+++ b/ta/qcom_pas/include/pas_mbn_parser_priv.h
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_MBN_PARSER_PRIV_H
+#define __PAS_MBN_PARSER_PRIV_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * MBN hash-segment binary-format primitives, used by pas_mbn_parser.c for
+ * segment location and hash-table extraction.
+ */
+
+/* MBN header field offsets (bytes from hash-segment start) */
+#define MBN_OFF_VERSION		0x04
+#define MBN_OFF_QC_SIG_SIZE	0x08
+#define MBN_OFF_QC_CERT_SIZE	0x0c
+#define MBN_OFF_CODE_SIZE	0x14
+#define MBN_OFF_OEM_SIG_SIZE	0x1c
+#define MBN_OFF_OEM_CERT_SIZE	0x24
+#define MBN_OFF_QC_META_SIZE	0x28	/* v6 only */
+#define MBN_OFF_OEM_META_SIZE	0x2c	/* v6 only */
+
+#define MBN_HDR_SIZE_V5		0x28
+#define MBN_HDR_SIZE_V6		0x30
+
+/* Read a little-endian uint32_t from @p. */
+uint32_t pas_mbn_read_u32(const uint8_t *p);
+
+/*
+ * pas_mbn_locate() - locate the MBN hash segment inside an INIT_IMAGE blob
+ * @md:       INIT_IMAGE metadata blob (ELF preamble + hash segment)
+ * @md_size:  size of @md in bytes
+ * @seg:      out: pointer to the hash segment
+ * @seg_size: out: size of the hash segment in bytes
+ *
+ * Searches the program-header table for the phdr whose Qualcomm-specific
+ * p_flags type field marks it as the MBN hash segment.
+ */
+TEE_Result pas_mbn_locate(const uint8_t *md, size_t md_size,
+			  const uint8_t **seg, size_t *seg_size);
+
+/*
+ * pas_mbn_reserve_region() - slice a sub-region out of the hash segment
+ * @segment:      hash segment from pas_mbn_locate()
+ * @segment_size: size of @segment in bytes
+ * @offset:       in/out: byte offset within @segment; advanced by @len on
+ *                success
+ * @len:          length of the region to slice; 0 yields a NULL/zero-length
+ *                region without moving @offset
+ * @region:       out: pointer to the region, or NULL when @len is 0
+ * @region_len:   out: length of the region
+ */
+TEE_Result pas_mbn_reserve_region(const uint8_t *segment, size_t segment_size,
+				  size_t *offset, size_t len,
+				  const uint8_t **region, size_t *region_len);
+
+#endif /* __PAS_MBN_PARSER_PRIV_H */

--- a/ta/qcom_pas/include/pas_mbn_parser_priv.h
+++ b/ta/qcom_pas/include/pas_mbn_parser_priv.h
@@ -16,7 +16,7 @@
  * (OEM/QTI metadata, signature and certificate regions).
  */
 
-/* MBN header field offsets (bytes from hash-segment start) */
+/* MBN header field offsets (bytes from hash-segment start), v5/v6 layout */
 #define MBN_OFF_VERSION		0x04
 #define MBN_OFF_QC_SIG_SIZE	0x08
 #define MBN_OFF_QC_CERT_SIZE	0x0c
@@ -29,8 +29,30 @@
 #define MBN_HDR_SIZE_V5		0x28
 #define MBN_HDR_SIZE_V6		0x30
 
+/*
+ * MBN v7 header field offsets (bytes from hash-segment start). v7 has a
+ * different field order than v5/v6 and adds a common-metadata size field
+ * shared by both signers; there is no v7 equivalent of MBN_OFF_VERSION at
+ * the same offset as v5/v6 header word 1, so v7 is decoded through its own
+ * offsets rather than reusing the MBN_OFF_* v5/v6 constants above.
+ */
+#define MBN_OFF_V7_VERSION		0x04
+#define MBN_OFF_V7_COMMON_META_SIZE	0x08
+#define MBN_OFF_V7_QC_META_SIZE		0x0c
+#define MBN_OFF_V7_OEM_META_SIZE	0x10
+#define MBN_OFF_V7_CODE_SIZE		0x14
+#define MBN_OFF_V7_QC_SIG_SIZE		0x18
+#define MBN_OFF_V7_QC_CERT_SIZE	0x1c
+#define MBN_OFF_V7_OEM_SIG_SIZE	0x20
+#define MBN_OFF_V7_OEM_CERT_SIZE	0x24
+
+#define MBN_HDR_SIZE_V7			0x28
+
 /* Read a little-endian uint32_t from @p. */
 uint32_t pas_mbn_read_u32(const uint8_t *p);
+
+/* Read a little-endian uint64_t from @p. */
+uint64_t pas_mbn_read_u64(const uint8_t *p);
 
 /*
  * pas_mbn_locate() - locate the MBN hash segment inside an INIT_IMAGE blob

--- a/ta/qcom_pas/include/pas_meta.h
+++ b/ta/qcom_pas/include/pas_meta.h
@@ -1,0 +1,156 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_META_H
+#define __PAS_META_H
+
+#include <pas_mbn_parser.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * OEM/QTI metadata, signature and certificate-region access for the MBN hash
+ * segment. Builds on struct pas_mbn / pas_mbn_parse() (pas_mbn_parser.h),
+ * which locates these regions but does not itself interpret them.
+ */
+
+/*
+ * pas_meta_peek_version() - read the MBN header version ahead of the parse
+ * @meta_data:      INIT_IMAGE metadata blob (ELF preamble + hash segment)
+ * @meta_data_size: size of @meta_data in bytes
+ * @version: decoded MBN header version on success
+ *
+ * The segment hash table digest size depends on the MBN version (v5 is always
+ * SHA-256 by format definition; v6 selects SHA-256/SHA-384 via a fuse). This
+ * does a minimal header-only pass to read the version before choosing the
+ * digest size. Returns TEE_ERROR_BAD_FORMAT on a malformed segment.
+ */
+TEE_Result pas_meta_peek_version(const uint8_t *meta_data,
+				 size_t meta_data_size, uint32_t *version);
+
+/*
+ * pas_meta_peek_root_cert_sel() - read root_cert_sel ahead of the full parse
+ * @meta_data:		 INIT_IMAGE metadata blob (ELF preamble + hash segment)
+ * @meta_data_size:	 size of @meta_data in bytes
+ * @root_cert_sel: decoded metadata word 28 on success
+ *
+ * The digest size the segment hash table uses (SHA-256 vs SHA-384) is chosen
+ * per-image via the OEM metadata's root_cert_sel field, but that field lives
+ * inside the same metadata pas_mbn_parse() needs @hash_size to locate.
+ * This does a minimal header-only pass to read root_cert_sel before the real
+ * parse.
+ *
+ * Returns TEE_ERROR_NO_DATA when the segment carries no OEM metadata (v5, or
+ * an image signed without it) - the caller should then use the default
+ * root_cert_sel of 0. Returns TEE_ERROR_BAD_FORMAT on a malformed segment.
+ */
+TEE_Result pas_meta_peek_root_cert_sel(const uint8_t *meta_data,
+				       size_t meta_data_size,
+				       uint32_t *root_cert_sel);
+
+/*
+ * pas_meta_verify_preamble() - authenticate hash-table entry 0
+ * @meta_data:		 INIT_IMAGE metadata blob (ELF preamble + hash segment)
+ * @meta_data_size:	 size of @meta_data in bytes
+ * @hash_table:	 hash table from a successful pas_mbn_parse()
+ * @hash_size:	 digest size in bytes (32 or 48); selects the hash algorithm
+ *
+ * Entry 0 of the hash table digests the ELF header plus program-header
+ * table (the metadata blob's preamble) rather than a loaded segment.
+ * Authenticate it at INIT_IMAGE time, before any segment is loaded, rather
+ * than waiting for the per-segment check at AUTH_AND_RESET.
+ *
+ * Returns TEE_ERROR_NOT_SUPPORTED for an unrecognized @hash_size,
+ * TEE_ERROR_SECURITY on a digest mismatch, else TEE_SUCCESS.
+ */
+TEE_Result pas_meta_verify_preamble(const uint8_t *meta_data,
+				    size_t meta_data_size,
+				    const uint8_t *hash_table,
+				    uint32_t hash_size);
+
+/*
+ * struct pas_meta - decoded MBN v6 OEM metadata
+ * @major:		metadata major version
+ * @minor:		metadata minor version
+ * @sw_id:		image software type
+ * @hw_id:		JTAG/HW id bound value (when IN_USE_JTAG_ID set)
+ * @oem_id:		OEM id (bound unless OEM_ID_INDEPENDENT set)
+ * @model_id:		model/product id (bound unless MODEL_ID_INDEPENDENT set)
+ * @secondary_sw_id:	secondary software id
+ * @flags:		binding flags (see PAS_META_FLAG_*)
+ * @soc_vers:		accepted SoC family|device versions (when SOC_HW bound)
+ * @serial_num:		accepted device serials (when serial binding set)
+ * @root_cert_sel:	index of the root certificate this image chains to
+ * @anti_rollback:	minimum image version permitted (rollback floor)
+ *
+ * Decodes the Qualcomm OEM metadata structure embedded in the MBN hash
+ * segment. The fields PAS binds are decoded here; several are gated on
+ * @flags bits.
+ */
+struct pas_meta {
+	uint32_t major;
+	uint32_t minor;
+	uint32_t sw_id;
+	uint32_t hw_id;
+	uint32_t oem_id;
+	uint32_t model_id;
+	uint32_t secondary_sw_id;
+	uint32_t flags;
+	uint32_t soc_vers[12];
+	uint32_t serial_num[8];
+	uint32_t root_cert_sel;
+	uint32_t anti_rollback;
+};
+
+/*
+ * Metadata @flags bit positions. Fields whose "independent" bit is set are
+ * not bound; SoC/JTAG/serial are bound only when their "in use" bit is set.
+ */
+#define PAS_META_FLAG_IN_USE_SOC_HW_VERSION	1
+#define PAS_META_FLAG_USE_SERIAL_NUMBER		2
+#define PAS_META_FLAG_OEM_ID_INDEPENDENT	3
+#define PAS_META_FLAG_IN_USE_JTAG_ID		10
+#define PAS_META_FLAG_MODEL_ID_INDEPENDENT	11
+
+/*
+ * 2-bit option fields within @flags (root-revoke/activate, UIE key switch,
+ * debug re-enable). Valid values are 0-2; 3 is reserved and rejected. Value 2
+ * is the SN-gated enable for all three fields: it requires the device serial
+ * to match the metadata allow-list. (Root-revoke/activate and UIE key-switch
+ * value 1 is a plain enable with no serial requirement; the debug option has
+ * no such plain-enable value - 0 is NOP, 1 is DISABLE, 2 is the only ENABLE.)
+ */
+#define PAS_META_FLAG_ROOT_REVOKE_ACTIVATE_SHIFT	4
+#define PAS_META_FLAG_UIE_KEY_SWITCH_SHIFT		6
+#define PAS_META_FLAG_DEBUG_SHIFT			8
+#define PAS_META_OPTION_MASK				3U
+#define PAS_META_OPTION_MAX				2U
+#define PAS_META_OPTION_ENABLE_SN			2U
+
+/*
+ * pas_meta_get() - decode the OEM metadata fields from a hash segment
+ * @hs:   parsed hash segment
+ * @meta: decoded metadata on success
+ *
+ * Returns TEE_ERROR_NO_DATA when the segment carries no OEM metadata (v5 or an
+ * image signed without it), TEE_ERROR_BAD_FORMAT on a short block, else
+ * TEE_SUCCESS.
+ */
+TEE_Result pas_meta_get(const struct pas_mbn *hs, struct pas_meta *meta);
+
+/*
+ * pas_meta_signed_copy() - build the OEM-signed-region bytes
+ * @hs:     parsed hash segment
+ * @out:    receives a newly allocated copy of the signed region
+ * @out_len: receives the length of @out
+ *
+ * The OEM signature is computed over the signed region with the QTI header
+ * size fields and QTI metadata block zeroed. The caller must TEE_Free(*out).
+ */
+TEE_Result pas_meta_signed_copy(const struct pas_mbn *hs,
+				uint8_t **out, size_t *out_len);
+
+#endif /* __PAS_META_H */

--- a/ta/qcom_pas/include/pas_meta.h
+++ b/ta/qcom_pas/include/pas_meta.h
@@ -54,8 +54,8 @@ TEE_Result pas_meta_peek_root_cert_sel(const uint8_t *meta_data,
 
 /*
  * pas_meta_peek_hash_table_algo() - read the v7 segment-hash digest size
- * @md:		 INIT_IMAGE metadata blob (ELF preamble + hash segment)
- * @md_size:	 size of @md in bytes
+ * @meta_data:      INIT_IMAGE metadata blob (ELF preamble + hash segment)
+ * @meta_data_size: size of @meta_data in bytes
  * @hash_size:	 decoded digest size (32 or 48) on success
  *
  * MBN v7 selects the segment hash-table's digest algorithm via the common
@@ -67,7 +67,8 @@ TEE_Result pas_meta_peek_root_cert_sel(const uint8_t *meta_data,
  * Returns TEE_ERROR_NOT_SUPPORTED for an unrecognized algorithm,
  * TEE_ERROR_BAD_FORMAT on a malformed segment.
  */
-TEE_Result pas_meta_peek_hash_table_algo(const uint8_t *md, size_t md_size,
+TEE_Result pas_meta_peek_hash_table_algo(const uint8_t *meta_data,
+					 size_t meta_data_size,
 					 uint32_t *hash_size);
 
 /*

--- a/ta/qcom_pas/include/pas_meta.h
+++ b/ta/qcom_pas/include/pas_meta.h
@@ -7,6 +7,7 @@
 #define __PAS_META_H
 
 #include <pas_mbn_parser.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <tee_api_types.h>
@@ -52,6 +53,24 @@ TEE_Result pas_meta_peek_root_cert_sel(const uint8_t *meta_data,
 				       uint32_t *root_cert_sel);
 
 /*
+ * pas_meta_peek_hash_table_algo() - read the v7 segment-hash digest size
+ * @md:		 INIT_IMAGE metadata blob (ELF preamble + hash segment)
+ * @md_size:	 size of @md in bytes
+ * @hash_size:	 decoded digest size (32 or 48) on success
+ *
+ * MBN v7 selects the segment hash-table's digest algorithm via the common
+ * metadata's hash_table_algo field (SHA-256 or SHA-384; SHA-512 and every
+ * zero-initialized-segment "_ZI" variant are rejected - see pas_meta.c).
+ * Unlike v6, this is not fuse-selected: it is a signed metadata field, so no
+ * fuse-PTA round trip is needed to pick the digest size for a v7 image.
+ *
+ * Returns TEE_ERROR_NOT_SUPPORTED for an unrecognized algorithm,
+ * TEE_ERROR_BAD_FORMAT on a malformed segment.
+ */
+TEE_Result pas_meta_peek_hash_table_algo(const uint8_t *md, size_t md_size,
+					 uint32_t *hash_size);
+
+/*
  * pas_meta_verify_preamble() - authenticate hash-table entry 0
  * @meta_data:		 INIT_IMAGE metadata blob (ELF preamble + hash segment)
  * @meta_data_size:	 size of @meta_data in bytes
@@ -72,25 +91,37 @@ TEE_Result pas_meta_verify_preamble(const uint8_t *meta_data,
 				    uint32_t hash_size);
 
 /*
- * struct pas_meta - decoded MBN v6 OEM metadata
- * @major:		metadata major version
+ * struct pas_meta - decoded OEM metadata (MBN v6, or v7's per-signing block)
+ * @is_v7:		true if @flags uses the v7 2-bit "bound" encoding
+ *			(PAS_META7_FLAG_*_SHIFT); false for v6's single-bit
+ *			"independent" encoding (PAS_META_FLAG_*). Callers must
+ *			branch on this before interpreting @flags - the two
+ *			encodings use overlapping shift values with opposite
+ *			polarity and are never compatible.
+ * @major:		metadata major version (v6: 0 or 1; v7: 2 or 3)
  * @minor:		metadata minor version
- * @sw_id:		image software type
- * @hw_id:		JTAG/HW id bound value (when IN_USE_JTAG_ID set)
- * @oem_id:		OEM id (bound unless OEM_ID_INDEPENDENT set)
- * @model_id:		model/product id (bound unless MODEL_ID_INDEPENDENT set)
+ * @sw_id:		image software type (v7: from the common-metadata block)
+ * @hw_id:		JTAG/HW id bound value (when the JTAG binding gate
+ *			is set)
+ * @oem_id:		OEM id (bound unless its independent/not-bound gate
+ *			is set)
+ * @model_id:		model/product id (bound unless its gate is set)
  * @secondary_sw_id:	secondary software id
- * @flags:		binding flags (see PAS_META_FLAG_*)
+ * @flags:		binding flags; see @is_v7
  * @soc_vers:		accepted SoC family|device versions (when SOC_HW bound)
- * @serial_num:		accepted device serials (when serial binding set)
+ * @serial_num:		accepted device serials (when serial binding set);
+ *			v6 entries are 32-bit on the wire, v7 entries are
+ *			64-bit - widened to uint64_t here so one comparison
+ *			against the (32-bit) fused serial works for both
  * @root_cert_sel:	index of the root certificate this image chains to
  * @anti_rollback:	minimum image version permitted (rollback floor)
  *
- * Decodes the Qualcomm OEM metadata structure embedded in the MBN hash
+ * Mirrors the Qualcomm OEM metadata structure embedded in the MBN hash
  * segment. The fields PAS binds are decoded here; several are gated on
  * @flags bits.
  */
 struct pas_meta {
+	bool is_v7;
 	uint32_t major;
 	uint32_t minor;
 	uint32_t sw_id;
@@ -100,14 +131,15 @@ struct pas_meta {
 	uint32_t secondary_sw_id;
 	uint32_t flags;
 	uint32_t soc_vers[12];
-	uint32_t serial_num[8];
+	uint64_t serial_num[8];
 	uint32_t root_cert_sel;
 	uint32_t anti_rollback;
 };
 
 /*
- * Metadata @flags bit positions. Fields whose "independent" bit is set are
- * not bound; SoC/JTAG/serial are bound only when their "in use" bit is set.
+ * Metadata @flags bit positions (MBN v6 only - single "independent" bits).
+ * Fields whose "independent" bit is set are not bound; SoC/JTAG/serial are
+ * bound only when their "in use" bit is set.
  */
 #define PAS_META_FLAG_IN_USE_SOC_HW_VERSION	1
 #define PAS_META_FLAG_USE_SERIAL_NUMBER		2
@@ -131,6 +163,48 @@ struct pas_meta {
 #define PAS_META_OPTION_ENABLE_SN			2U
 
 /*
+ * Metadata @flags bit-pair shifts (MBN v7 only - "bound" pairs, NOT
+ * compatible with the v6 PAS_META_FLAG_* single-bit encoding above). Each
+ * field occupies 2 bits: "10" (MSB=1, LSB=0) means the field is bound and
+ * must be enforced, "01" (MSB=0, LSB=1) means it is not bound; "00"/"11" are
+ * invalid encodings (see pas_meta_v7_flags_valid()).
+ */
+#define PAS_META7_FLAG_SOC_HW_VERSION_BOUND_SHIFT	0
+#define PAS_META7_FLAG_JTAG_ID_BOUND_SHIFT		4
+#define PAS_META7_FLAG_SERIAL_NUMBER_BOUND_SHIFT	6
+#define PAS_META7_FLAG_OEM_ID_BOUND_SHIFT		8
+#define PAS_META7_FLAG_OEM_PRODUCT_ID_BOUND_SHIFT	10
+#define PAS_META7_FLAG_MAX_SHIFT			20
+
+/*
+ * pas_meta7_flag_bit() - read one bit of a v7 flags bit-pair
+ * @flags: metadata flags word
+ * @shift: bit-pair base shift (a PAS_META7_FLAG_*_SHIFT value)
+ * @msb:   true to read the pair's high bit, false for the low bit
+ */
+static inline bool pas_meta7_flag_bit(uint32_t flags, uint32_t shift,
+				      bool msb)
+{
+	return (flags >> (shift + (msb ? 1 : 0))) & 1;
+}
+
+/*
+ * pas_meta7_flag_bound() - true if the v7 flags bit-pair at @shift is "10"
+ * (bound). Does not validate the pair; call pas_meta7_flags_valid() first.
+ */
+static inline bool pas_meta7_flag_bound(uint32_t flags, uint32_t shift)
+{
+	return pas_meta7_flag_bit(flags, shift, true) &&
+	       !pas_meta7_flag_bit(flags, shift, false);
+}
+
+/*
+ * pas_meta7_flags_valid() - true if every 2-bit field in a v7 flags word is
+ * "10" or "01" (never "00"/"11")
+ */
+bool pas_meta7_flags_valid(uint32_t flags);
+
+/*
  * pas_meta_get() - decode the OEM metadata fields from a hash segment
  * @hs:   parsed hash segment
  * @meta: decoded metadata on success
@@ -142,7 +216,7 @@ struct pas_meta {
 TEE_Result pas_meta_get(const struct pas_mbn *hs, struct pas_meta *meta);
 
 /*
- * pas_meta_signed_copy() - build the OEM-signed-region bytes
+ * pas_meta_oem_signed_copy() - build the OEM-signed-region bytes
  * @hs:     parsed hash segment
  * @out:    receives a newly allocated copy of the signed region
  * @out_len: receives the length of @out
@@ -150,7 +224,7 @@ TEE_Result pas_meta_get(const struct pas_mbn *hs, struct pas_meta *meta);
  * The OEM signature is computed over the signed region with the QTI header
  * size fields and QTI metadata block zeroed. The caller must TEE_Free(*out).
  */
-TEE_Result pas_meta_signed_copy(const struct pas_mbn *hs,
-				uint8_t **out, size_t *out_len);
+TEE_Result pas_meta_oem_signed_copy(const struct pas_mbn *hs,
+				    uint8_t **out, size_t *out_len);
 
 #endif /* __PAS_META_H */

--- a/ta/qcom_pas/include/pas_policy.h
+++ b/ta/qcom_pas/include/pas_policy.h
@@ -1,0 +1,50 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_POLICY_H
+#define __PAS_POLICY_H
+
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/*
+ * PAS image-binding policy.
+ *
+ * Each subsystem is bound to a fixed software-id (SW_ID) so that a validly-
+ * signed image for one peripheral cannot be loaded onto another, and each
+ * SW_ID has a required signing authority.
+ */
+
+/*
+ * Signing authority required for an image. pas_policy_signer() returns
+ * PAS_OEM_SIGNED for every SW_ID this port supports; PAS_QTI_SIGNED and
+ * PAS_DOUBLE_SIGNED are declared so callers can name every defined class,
+ * even though QTI countersignature verification is not implemented here
+ * and no supported peripheral requires it.
+ */
+enum pas_sign_authority {
+	PAS_OEM_SIGNED = 0,
+	PAS_QTI_SIGNED = 1,
+	PAS_DOUBLE_SIGNED = 2,
+};
+
+/*
+ * pas_policy_expected_swid() - expected SW_ID for a peripheral
+ * @pas_id: unique remote-processor identifier (invoke params[0].a)
+ * @swid:   expected SW_ID on success
+ *
+ * Returns TEE_ERROR_NOT_SUPPORTED if the pas_id has no known binding.
+ */
+TEE_Result pas_policy_expected_swid(uint32_t pas_id, uint32_t *swid);
+
+/*
+ * pas_policy_signer() - required signing authority for a SW_ID
+ * @swid: image software id
+ *
+ * Returns PAS_OEM_SIGNED for every SW_ID this port supports.
+ */
+enum pas_sign_authority pas_policy_signer(uint32_t swid);
+
+#endif /* __PAS_POLICY_H */

--- a/ta/qcom_pas/include/pas_sig.h
+++ b/ta/qcom_pas/include/pas_sig.h
@@ -1,0 +1,96 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_AUTH_SIG_H
+#define __PAS_AUTH_SIG_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <tee_api_types.h>
+
+/* Maximum supported digest size (SHA-384). */
+#define PAS_AUTH_MAX_HASH_SIZE		48U
+
+/*
+ * pas_sig_verify_cert_chain() - parse and validate a DER certificate chain
+ * @chain_der:      concatenated X.509 DER, leaf first, root(s) last
+ * @chain_der_len:  length of @chain_der
+ * @eku_enforced:   require the leaf to carry the code-signing Extended Key
+ *                  Usage OID, gated on the OEM_CONFIG2 EKU_ENFORCEMENT_EN fuse
+ * @num_roots:      number of provisioned root certificates in the chain (1 for
+ *                  a conventional single-root chain; 2..4 when multiple roots
+ *                  are provisioned)
+ * @root_cert_sel:  index of the root the image chains to (0 when single-root)
+ * @leaf_der:       out: pointer into @chain_der for the leaf cert
+ * @leaf_der_len:   out: length of the leaf cert
+ * @roots_der:      out (optional): pointer into @chain_der for the root region;
+ *                  spans all @num_roots roots concatenated (single root when
+ *                  @num_roots is 1). Pass NULL when not needed.
+ * @roots_der_len:  out (optional): length of the root region; pass NULL when
+ *                  not needed.
+ *
+ * With multiple roots, the chain is [leaf, (intermediate,) root_0..root_N-1];
+ * the leaf is verified up to the @root_cert_sel-th root, and the returned
+ * root region covers every provisioned root for binding to the device
+ * root-of-trust digest. Verifies internal chain consistency using mbedTLS.
+ * The returned DER pointers reference @chain_der and remain valid for its
+ * lifetime.
+ */
+TEE_Result pas_sig_verify_cert_chain(const uint8_t *chain_der,
+				     size_t chain_der_len, bool eku_enforced,
+				     uint32_t num_roots,
+				     uint32_t root_cert_sel,
+				     const uint8_t **leaf_der,
+				     size_t *leaf_der_len,
+				     const uint8_t **roots_der,
+				     size_t *roots_der_len);
+
+/*
+ * pas_sig_check_root_of_trust() - bind the chain root to the device anchor
+ * @hash_algo:    TEE_ALG_SHA256 or TEE_ALG_SHA384
+ * @hash_size:    digest size in bytes
+ * @root_der:     DER bytes of the chain root certificate
+ * @root_der_len: length of @root_der
+ * @expected:     expected digest from the OTP root-of-trust fuse
+ */
+TEE_Result pas_sig_check_root_of_trust(uint32_t hash_algo, size_t hash_size,
+				       const uint8_t *root_der,
+				       size_t root_der_len,
+				       const uint8_t *expected);
+
+/*
+ * pas_sig_algo_from_leaf() - pick signature scheme + digest from the leaf
+ * @leaf_der:     DER bytes of the leaf certificate
+ * @leaf_der_len: length of @leaf_der
+ * @sig_algo:     out: matching TEE signature algorithm
+ * @hash_algo:    out: message digest bound to the signature scheme
+ *                (ECDSA -> SHA-384)
+ *
+ * The digest is derived from the leaf key type rather than supplied by the
+ * caller, so the image uses the digest its signature was produced with.
+ */
+TEE_Result pas_sig_algo_from_leaf(const uint8_t *leaf_der,
+				  size_t leaf_der_len, uint32_t *sig_algo,
+				  uint32_t *hash_algo);
+
+/*
+ * pas_sig_verify_signature() - verify a signature using the leaf certificate
+ * @sig_algo:    TEE signature algorithm (ECDSA)
+ * @hash_algo:   matching digest algorithm
+ * @leaf_der:    DER bytes of the leaf certificate
+ * @leaf_der_len: length of @leaf_der
+ * @msg:         signed message
+ * @msg_len:     length of @msg
+ * @sig:         signature bytes
+ * @sig_len:     length of @sig
+ */
+TEE_Result pas_sig_verify_signature(uint32_t sig_algo, uint32_t hash_algo,
+				    const uint8_t *leaf_der,
+				    size_t leaf_der_len,
+				    const uint8_t *msg, size_t msg_len,
+				    const uint8_t *sig, size_t sig_len);
+
+#endif /* __PAS_AUTH_SIG_H */

--- a/ta/qcom_pas/include/pas_sig_auth.h
+++ b/ta/qcom_pas/include/pas_sig_auth.h
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __PAS_SIG_AUTH_H
+#define __PAS_SIG_AUTH_H
+
+#include <pas_mbn_parser.h>
+#include <qcom_pas_priv.h>
+#include <tee_internal_api.h>
+
+/*
+ * Signature-authentication backend for the PAS TA: certificate chain,
+ * signature, SW_ID/HW binding and anti-rollback. Runs this crypto work
+ * BEFORE the REE loads any ELF segment into the carveout, between parsing
+ * the hash table and trusting it.
+ */
+
+#ifdef CFG_QCOM_PAS_AUTH
+/*
+ * Determine the per-segment hash digest size for @slot's metadata. The OEM
+ * metadata's root_cert_sel selects the fuse-configured algorithm on
+ * platforms that implement the field; MBN v5 images (no OEM metadata) always
+ * use SHA-256.
+ */
+TEE_Result pas_sig_auth_hash_size(const struct pas_md_slot *slot,
+				  uint32_t *hash_size);
+
+/*
+ * Authenticate @hs (already parsed by pas_mbn_parse()): reject
+ * UIE-encrypted images, verify the certificate chain, signature and
+ * fuse-bound bindings, verify the hash-table preamble entry, and enforce
+ * anti-rollback. @meta_data/@meta_data_size are the same INIT_IMAGE
+ * metadata blob @hs was parsed from. @anchor is the OEM root-of-trust
+ * digest the caller already read from the fuse PTA
+ * (PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE bytes); callable only when the caller's
+ * secure-boot gate is on, so every check here is unconditional.
+ */
+TEE_Result pas_sig_auth_authenticate(const struct pas_mbn *hs,
+				     const uint8_t *meta_data,
+				     size_t meta_data_size,
+				     uint32_t pas_id, uint32_t hash_size,
+				     const uint8_t *anchor);
+#else
+static inline TEE_Result
+pas_sig_auth_hash_size(const struct pas_md_slot *slot __unused,
+		       uint32_t *hash_size)
+{
+	*hash_size = TEE_SHA384_HASH_SIZE;
+	return TEE_SUCCESS;
+}
+
+static inline TEE_Result
+pas_sig_auth_authenticate(const struct pas_mbn *hs __unused,
+			  const uint8_t *meta_data __unused,
+			  size_t meta_data_size __unused,
+			  uint32_t pas_id __unused,
+			  uint32_t hash_size __unused,
+			  const uint8_t *anchor __unused)
+{
+	return TEE_SUCCESS;
+}
+#endif /* CFG_QCOM_PAS_AUTH */
+
+#endif /* __PAS_SIG_AUTH_H */

--- a/ta/qcom_pas/include/qcom_pas_priv.h
+++ b/ta/qcom_pas/include/qcom_pas_priv.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef __QCOM_PAS_PRIV_H
+#define __QCOM_PAS_PRIV_H
+
+#include <pas_mbn_parser.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/*
+ * Per-session context shared between the command dispatch (qcom_pas.c) and
+ * the authentication backend (pas_auth.c).
+ *
+ * The firmware metadata is saved at INIT_IMAGE inside a TEE-private copy so
+ * the REE cannot alter it between INIT_IMAGE and AUTH_AND_RESET. Keeping it
+ * per-session (rather than as a TA global) ensures two concurrent sessions
+ * cannot observe each other's metadata.
+ *
+ * The remoteproc driver opens one TEE session shared by every peripheral,
+ * and DSPs load concurrently. Metadata must therefore be keyed by pas_id to
+ * prevent one DSP's INIT_IMAGE overwriting another's slot before its
+ * AUTH_AND_RESET runs. The table is sized per platform to cover the number
+ * of PAS subsystems a target exposes: a target overrides CFG_PAS_MD_SLOTS
+ * to size it up, and it defaults to a single slot otherwise.
+ */
+#ifndef CFG_PAS_MD_SLOTS
+#define CFG_PAS_MD_SLOTS	1U
+#endif
+#define PAS_MD_SLOTS		CFG_PAS_MD_SLOTS
+
+struct pas_md_slot {
+	void *meta_data;
+	size_t meta_data_size;
+	uint32_t pas_id;
+	bool used;
+	struct pas_mbn mbn;
+	bool hash_table_valid;
+};
+
+struct qcom_pas_session {
+	struct pas_md_slot slots[PAS_MD_SLOTS];
+};
+
+#endif /* __QCOM_PAS_PRIV_H */

--- a/ta/qcom_pas/include/qcom_pas_priv.h
+++ b/ta/qcom_pas/include/qcom_pas_priv.h
@@ -38,6 +38,11 @@ struct pas_md_slot {
 	uint32_t pas_id;
 	bool used;
 	struct pas_mbn mbn;
+	/*
+	 * True once pas_mbn_parse() has located a table for this slot and,
+	 * on secure-boot devices, every signature-authentication check has
+	 * passed. Gates AUTH_AND_RESET.
+	 */
 	bool hash_table_valid;
 };
 

--- a/ta/qcom_pas/src/pas_auth.c
+++ b/ta/qcom_pas/src/pas_auth.c
@@ -4,15 +4,19 @@
  */
 
 /*
- * Firmware integrity backend for the PAS TA. Built under
+ * Firmware authentication backend for the PAS TA. Built under
  * CFG_QCOM_PAS_AUTH; see pas_auth.h for the INIT_IMAGE/AUTH_AND_RESET flow.
  */
 
 #include <pas_auth.h>
+#include <pas_fuse.h>
 #include <pas_mbn_parser.h>
+#include <pas_sig_auth.h>
+#include <pta_qcom_fuse.h>
 #include <pta_qcom_pas.h>
 #include <qcom_pas_priv.h>
 #include <string.h>
+#include <string_ext.h>
 #include <tee_internal_api.h>
 #include <utee_defines.h>
 
@@ -45,6 +49,10 @@ TEE_Result pas_auth_save_metadata(struct qcom_pas_session *s, uint32_t pt,
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
 
+	size = params[1].memref.size;
+	if (size && !params[1].memref.buffer)
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	pas_id = params[0].value.a;
 
 	/* Reuse the existing slot for this pas_id, else take a free one. */
@@ -62,7 +70,6 @@ TEE_Result pas_auth_save_metadata(struct qcom_pas_session *s, uint32_t pt,
 		return TEE_ERROR_OUT_OF_MEMORY;
 	}
 
-	size = params[1].memref.size;
 	if (size) {
 		meta_data_copy = TEE_Malloc(size, TEE_MALLOC_FILL_ZERO);
 		if (!meta_data_copy)
@@ -83,8 +90,11 @@ TEE_Result pas_auth_save_metadata(struct qcom_pas_session *s, uint32_t pt,
 
 TEE_Result pas_auth_authenticate(struct qcom_pas_session *s, uint32_t pas_id)
 {
+	uint8_t anchor[PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE] = { };
 	struct pas_md_slot *slot = get_meta_data_slot(s, pas_id);
 	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t hash_size = TEE_SHA384_HASH_SIZE;
+	bool secboot_on = false;
 
 	if (!slot) {
 		EMSG("PAS auth: no metadata for pas_id=%"PRIu32
@@ -92,16 +102,53 @@ TEE_Result pas_auth_authenticate(struct qcom_pas_session *s, uint32_t pas_id)
 		return TEE_ERROR_BAD_STATE;
 	}
 
-	res = pas_mbn_parse(slot->meta_data, slot->meta_data_size,
-			    TEE_SHA384_HASH_SIZE, &slot->mbn);
+	/*
+	 * Read secure-boot enable state once and fork the entire
+	 * authentication path on that one value.
+	 */
+	res = pas_fuse_get_secboot_and_root_anchor(anchor, &secboot_on);
+	/*
+	 * Fail closed on a fuse-read failure: treat as secure-boot enabled.
+	 * Treating it as "not provisioned" would downgrade a secure-booted
+	 * board to hash-only authentication for the rest of the boot.
+	 */
+	if (res)
+		secboot_on = true;
+
+	/*
+	 * On secure-boot devices the segment-hash algorithm is selected by
+	 * the OEM metadata's root_cert_sel field, read via the fuse PTA.
+	 * On unprovisioned devices default to SHA-384.
+	 */
+	if (secboot_on) {
+		res = pas_sig_auth_hash_size(slot, &hash_size);
+		if (res) {
+			EMSG("PAS auth: cannot pick hash size: %#"PRIx32, res);
+			goto out;
+		}
+	}
+
+	res = pas_mbn_parse(slot->meta_data, slot->meta_data_size, hash_size,
+			    &slot->mbn);
 	if (res) {
 		EMSG("PAS auth: MBN parse failed: %#"PRIx32, res);
-		return res;
+		goto out;
+	}
+
+	if (secboot_on) {
+		res = pas_sig_auth_authenticate(&slot->mbn, slot->meta_data,
+						slot->meta_data_size, pas_id,
+						hash_size, anchor);
+		if (res)
+			goto out;
 	}
 
 	slot->hash_table_valid = true;
+	res = TEE_SUCCESS;
+out:
+	memzero_explicit(anchor, sizeof(anchor));
 
-	return TEE_SUCCESS;
+	return res;
 }
 
 TEE_Result pas_auth_verify_reset(struct qcom_pas_session *s,

--- a/ta/qcom_pas/src/pas_auth.c
+++ b/ta/qcom_pas/src/pas_auth.c
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/*
+ * Firmware integrity backend for the PAS TA. Built under
+ * CFG_QCOM_PAS_AUTH; see pas_auth.h for the INIT_IMAGE/AUTH_AND_RESET flow.
+ */
+
+#include <pas_auth.h>
+#include <pas_mbn_parser.h>
+#include <pta_qcom_pas.h>
+#include <qcom_pas_priv.h>
+#include <string.h>
+#include <tee_internal_api.h>
+#include <utee_defines.h>
+
+static struct pas_md_slot *get_meta_data_slot(struct qcom_pas_session *s,
+					      uint32_t pas_id)
+{
+	size_t i = 0;
+
+	for (i = 0; i < PAS_MD_SLOTS; i++) {
+		if (s->slots[i].used && s->slots[i].pas_id == pas_id)
+			return &s->slots[i];
+	}
+
+	return NULL;
+}
+
+TEE_Result pas_auth_save_metadata(struct qcom_pas_session *s, uint32_t pt,
+				  TEE_Param params[TEE_NUM_PARAMS])
+{
+	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+						TEE_PARAM_TYPE_MEMREF_INPUT,
+						TEE_PARAM_TYPE_NONE,
+						TEE_PARAM_TYPE_NONE);
+	struct pas_md_slot *slot = NULL;
+	uint32_t pas_id = 0;
+	void *meta_data_copy = NULL;
+	size_t size = 0;
+	size_t i = 0;
+
+	if (pt != exp_pt)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	pas_id = params[0].value.a;
+
+	/* Reuse the existing slot for this pas_id, else take a free one. */
+	slot = get_meta_data_slot(s, pas_id);
+	if (!slot) {
+		for (i = 0; i < PAS_MD_SLOTS; i++) {
+			if (!s->slots[i].used) {
+				slot = &s->slots[i];
+				break;
+			}
+		}
+	}
+	if (!slot) {
+		EMSG("PAS auth: no free md slot (pas_id=%"PRIu32")", pas_id);
+		return TEE_ERROR_OUT_OF_MEMORY;
+	}
+
+	size = params[1].memref.size;
+	if (size) {
+		meta_data_copy = TEE_Malloc(size, TEE_MALLOC_FILL_ZERO);
+		if (!meta_data_copy)
+			return TEE_ERROR_OUT_OF_MEMORY;
+		memcpy(meta_data_copy, params[1].memref.buffer, size);
+	}
+
+	TEE_Free(slot->meta_data);
+	slot->meta_data = meta_data_copy;
+	slot->meta_data_size = size;
+	slot->pas_id = pas_id;
+	slot->used = true;
+	slot->hash_table_valid = false;
+	memset(&slot->mbn, 0, sizeof(slot->mbn));
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_auth_authenticate(struct qcom_pas_session *s, uint32_t pas_id)
+{
+	struct pas_md_slot *slot = get_meta_data_slot(s, pas_id);
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	if (!slot) {
+		EMSG("PAS auth: no metadata for pas_id=%"PRIu32
+		     " (call INIT_IMAGE first)", pas_id);
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	res = pas_mbn_parse(slot->meta_data, slot->meta_data_size,
+			    TEE_SHA384_HASH_SIZE, &slot->mbn);
+	if (res) {
+		EMSG("PAS auth: MBN parse failed: %#"PRIx32, res);
+		return res;
+	}
+
+	slot->hash_table_valid = true;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_auth_verify_reset(struct qcom_pas_session *s,
+				 TEE_TASessionHandle pta_session,
+				 uint32_t pas_id,
+				 TEE_Param params[TEE_NUM_PARAMS])
+{
+	struct pas_md_slot *slot = get_meta_data_slot(s, pas_id);
+	TEE_Param vp[TEE_NUM_PARAMS] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t buffer_size = 0;
+	uint8_t *buffer = NULL;
+	uint32_t pt = 0;
+
+	if (!slot || !slot->hash_table_valid) {
+		EMSG("PAS auth: pas_id=%"PRIu32
+		     " has no hash table (call INIT_IMAGE first)", pas_id);
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	if (ADD_OVERFLOW(slot->meta_data_size, slot->mbn.hash_table_size,
+			 &buffer_size))
+		return TEE_ERROR_OVERFLOW;
+
+	buffer = TEE_Malloc(buffer_size, TEE_MALLOC_FILL_ZERO);
+	if (!buffer)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	TEE_MemMove(buffer, slot->meta_data, slot->meta_data_size);
+	TEE_MemMove(buffer + slot->meta_data_size, slot->mbn.hash_table,
+		    slot->mbn.hash_table_size);
+
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+			     TEE_PARAM_TYPE_VALUE_INPUT,
+			     TEE_PARAM_TYPE_MEMREF_INPUT,
+			     TEE_PARAM_TYPE_VALUE_INPUT);
+
+	vp[0].value.a = params[0].value.a;
+	vp[0].value.b = params[0].value.b;
+	vp[1].value.a = params[1].value.a;
+	vp[1].value.b = params[1].value.b;
+	vp[2].memref.buffer = buffer;
+	vp[2].memref.size = buffer_size;
+	vp[3].value.a = slot->mbn.hash_size;
+	/* hash-table offset within the packed buffer */
+	vp[3].value.b = slot->meta_data_size;
+
+	res = TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
+				  PTA_QCOM_PAS_VERIFY_IMAGE, pt, vp, NULL);
+
+	TEE_Free(buffer);
+	return res;
+}

--- a/ta/qcom_pas/src/pas_fuse.c
+++ b/ta/qcom_pas/src/pas_fuse.c
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <pas_fuse.h>
+#include <pta_qcom_fuse.h>
+#include <string.h>
+#include <tee_internal_api.h>
+
+/*
+ * One session to the fuse PTA, held for the TA's lifetime (opened in
+ * pas_fuse_open(), closed in pas_fuse_close()) and reused by every call
+ * below.
+ */
+static TEE_TASessionHandle fuse_session;
+
+TEE_Result pas_fuse_open(void)
+{
+	static const TEE_UUID fuse_uuid = PTA_QCOM_FUSE_UUID;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = TEE_OpenTASession(&fuse_uuid, TEE_TIMEOUT_INFINITE, 0, NULL,
+				&fuse_session, NULL);
+	if (res)
+		EMSG("PAS fuse: cannot open fuse PTA: %#"PRIx32, res);
+
+	return res;
+}
+
+void pas_fuse_close(void)
+{
+	TEE_CloseTASession(fuse_session);
+}
+
+/* Invoke @cmd on the shared session; callers apply their own policy. */
+static TEE_Result fuse_pta_invoke(uint32_t cmd, uint32_t param_types,
+				  TEE_Param params[TEE_NUM_PARAMS])
+{
+	return TEE_InvokeTACommand(fuse_session, TEE_TIMEOUT_INFINITE, cmd,
+				   param_types, params, NULL);
+}
+
+TEE_Result pas_fuse_get_secboot_and_root_anchor(uint8_t *anchor,
+						bool *secboot_on)
+{
+	TEE_Param params[TEE_NUM_PARAMS] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t pt = 0;
+
+	*secboot_on = false;
+
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE,
+			     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+	res = fuse_pta_invoke(PTA_QCOM_FUSE_GET_SECBOOT_STATE, pt, params);
+	if (res) {
+		EMSG("PAS fuse: cannot read secboot state: %#"PRIx32, res);
+		return res;
+	}
+	*secboot_on = params[0].value.a != 0;
+
+	memset(params, 0, sizeof(params));
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_OUTPUT, TEE_PARAM_TYPE_NONE,
+			     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+	params[0].memref.buffer = anchor;
+	params[0].memref.size = PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE;
+	res = fuse_pta_invoke(PTA_QCOM_FUSE_GET_ROOT_OF_TRUST, pt, params);
+	if (res)
+		EMSG("PAS fuse: cannot read root of trust: %#"PRIx32, res);
+
+	return res;
+}
+
+TEE_Result pas_fuse_get_hw_binding_info(bool need_soc_vers,
+					struct pas_fuse_hw_binding_info *info)
+{
+	TEE_Param params[TEE_NUM_PARAMS] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t pt = 0;
+
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT,
+			     TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE,
+			     TEE_PARAM_TYPE_NONE);
+	res = fuse_pta_invoke(PTA_QCOM_FUSE_GET_DEVICE_IDS, pt, params);
+	if (res) {
+		EMSG("PAS fuse: cannot read device ids: %#"PRIx32, res);
+		return res;
+	}
+	info->oem_id = params[0].value.a;
+	info->model_id = params[0].value.b;
+	info->jtag_id = params[1].value.a;
+	info->serial_num = params[1].value.b;
+
+	memset(params, 0, sizeof(params));
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE,
+			     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+	res = fuse_pta_invoke(PTA_QCOM_FUSE_GET_USE_SERIAL_NUM, pt, params);
+	if (res) {
+		EMSG("PAS fuse: cannot read USE_SERIAL_NUM fuse: %#"PRIx32,
+		     res);
+		return res;
+	}
+	info->use_serial_num_override = params[0].value.a;
+
+	if (!need_soc_vers)
+		return TEE_SUCCESS;
+
+	memset(params, 0, sizeof(params));
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE,
+			     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+	res = fuse_pta_invoke(PTA_QCOM_FUSE_GET_SOC_HW_VERSION, pt, params);
+	if (res) {
+		EMSG("PAS fuse: cannot read SOC_HW_VERSION: %#"PRIx32, res);
+		return res;
+	}
+	info->soc_fam_dev = params[0].value.a;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_fuse_get_eku_enforcement_en(bool *eku_enforced)
+{
+	TEE_Param params[TEE_NUM_PARAMS] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t pt = 0;
+
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE,
+			     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+	res = fuse_pta_invoke(PTA_QCOM_FUSE_GET_EKU_ENFORCEMENT_EN, pt, params);
+	if (res) {
+		EMSG("PAS fuse: cannot read EKU enforcement fuse: %#"PRIx32,
+		     res);
+		return res;
+	}
+
+	*eku_enforced = params[0].value.a;
+
+	return TEE_SUCCESS;
+}
+
+bool pas_fuse_get_image_encryption_en(void)
+{
+	TEE_Param params[TEE_NUM_PARAMS] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t pt = 0;
+
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_OUTPUT, TEE_PARAM_TYPE_NONE,
+			     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+	res = fuse_pta_invoke(PTA_QCOM_FUSE_GET_IMAGE_ENCRYPTION_EN, pt,
+			      params);
+	if (res) {
+		EMSG("PAS fuse: cannot read image encryption fuse: %#"PRIx32,
+		     res);
+		return true;
+	}
+
+	return params[0].value.a;
+}
+
+TEE_Result pas_fuse_get_segment_hash_size(uint32_t root_cert_sel,
+					  uint32_t *hash_size)
+{
+	TEE_Param params[TEE_NUM_PARAMS] = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t pt = 0;
+
+	params[0].value.a = root_cert_sel;
+	pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INOUT, TEE_PARAM_TYPE_NONE,
+			     TEE_PARAM_TYPE_NONE, TEE_PARAM_TYPE_NONE);
+	res = fuse_pta_invoke(PTA_QCOM_FUSE_GET_SEGMENT_HASH_SIZE, pt, params);
+	if (res) {
+		EMSG("PAS fuse: cannot read segment hash size: %#"PRIx32, res);
+		return res;
+	}
+
+	*hash_size = params[0].value.b;
+
+	return TEE_SUCCESS;
+}

--- a/ta/qcom_pas/src/pas_mbn_parser.c
+++ b/ta/qcom_pas/src/pas_mbn_parser.c
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <elf32.h>
+#include <elf64.h>
+#include <pas_mbn_parser.h>
+#include <pas_mbn_parser_priv.h>
+#include <string.h>
+#include <tee_internal_api.h>
+#include <util.h>
+
+/*
+ * A UIE image-encryption parameter block, when present, follows the last cert
+ * region in the hash segment. Its header begins with this little-endian magic.
+ */
+#define UIE_ENC_PARAM_MAGIC	0x514D5349	/* "ISMQ" */
+
+/*
+ * Qualcomm program-header flags encode segment type in bits 24:26 of p_flags;
+ * a phdr for the MBN hash segment carries the HASH_SEGMENT type value 0x2.
+ */
+#define MBN_PT_FLAG_TYPE_MASK		0x07000000U
+#define MBN_PT_FLAG_HASH_TYPE_MASK	0x02000000U
+
+uint32_t pas_mbn_read_u32(const uint8_t *p)
+{
+	uint32_t v = 0;
+
+	memcpy(&v, p, sizeof(v));
+
+	return v;
+}
+
+TEE_Result pas_mbn_locate(const uint8_t *md, size_t md_size,
+			  const uint8_t **seg, size_t *seg_size)
+{
+	const unsigned char *ident = md;
+	size_t phoff = 0;
+	size_t phentsize = 0;
+	size_t phnum = 0;
+	size_t ehdr_size = 0;
+	size_t phent_min = 0;
+	size_t phtab_end = 0;
+	size_t hash_off = 0;
+	size_t hash_end = 0;
+	size_t hash_filesz = 0;
+	uint32_t hash_flags = 0;
+	size_t i = 0;
+	bool is_64 = false;
+	bool found = false;
+
+	if (md_size < EI_NIDENT)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ident[EI_MAG0] != ELFMAG0 || ident[EI_MAG1] != ELFMAG1 ||
+	    ident[EI_MAG2] != ELFMAG2 || ident[EI_MAG3] != ELFMAG3)
+		return TEE_ERROR_BAD_FORMAT;
+
+	/*
+	 * Both ELF classes are accepted; the MBN hash-segment header is
+	 * uint32-only in either case.
+	 */
+	switch (ident[EI_CLASS]) {
+	case ELFCLASS64:
+		is_64 = true;
+		ehdr_size = sizeof(Elf64_Ehdr);
+		phent_min = sizeof(Elf64_Phdr);
+		break;
+	case ELFCLASS32:
+		is_64 = false;
+		ehdr_size = sizeof(Elf32_Ehdr);
+		phent_min = sizeof(Elf32_Phdr);
+		break;
+	default:
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	if (md_size < ehdr_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (is_64) {
+		const Elf64_Ehdr *ehdr = (const void *)md;
+
+		phoff = ehdr->e_phoff;
+		phentsize = ehdr->e_phentsize;
+		phnum = ehdr->e_phnum;
+	} else {
+		const Elf32_Ehdr *ehdr = (const void *)md;
+
+		phoff = ehdr->e_phoff;
+		phentsize = ehdr->e_phentsize;
+		phnum = ehdr->e_phnum;
+	}
+
+	if (phnum < 2 || !phoff || phentsize < phent_min)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (MUL_OVERFLOW(phentsize, phnum, &phtab_end) ||
+	    ADD_OVERFLOW(phtab_end, phoff, &phtab_end) ||
+	    phtab_end > md_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	/*
+	 * Find the phdr whose p_flags type bits mark it as the hash
+	 * segment.
+	 */
+	for (i = 0; i < phnum; i++) {
+		const uint8_t *p = md + phoff + i * phentsize;
+
+		if (is_64) {
+			const Elf64_Phdr *phdr = (const void *)p;
+
+			hash_flags = phdr->p_flags;
+			hash_filesz = phdr->p_filesz;
+		} else {
+			const Elf32_Phdr *phdr = (const void *)p;
+
+			hash_flags = phdr->p_flags;
+			hash_filesz = phdr->p_filesz;
+		}
+
+		if ((hash_flags & MBN_PT_FLAG_TYPE_MASK) ==
+		    MBN_PT_FLAG_HASH_TYPE_MASK) {
+			found = true;
+			break;
+		}
+	}
+	if (!found)
+		return TEE_ERROR_BAD_FORMAT;
+
+	/*
+	 * QTEE-aligned offset calculation (PIL_parseMetadata):
+	 *   hash_seg_offset = ehSize + phentSize * phNum
+	 *
+	 * The Linux kernel's qcom_mdt_read_metadata() packs the metadata
+	 * buffer as [ELF-header+phdrs | hash-segment], so the hash segment
+	 * always starts immediately after the ELF header and program-header
+	 * table, regardless of the p_offset field in the program header.
+	 * Using p_offset would point into the original firmware file, which
+	 * is beyond the end of the repacked metadata buffer.
+	 */
+	if (MUL_OVERFLOW(phentsize, phnum, &hash_off) ||
+	    ADD_OVERFLOW(hash_off, ehdr_size, &hash_off))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (ADD_OVERFLOW(hash_off, hash_filesz, &hash_end) ||
+	    hash_end > md_size || !hash_filesz)
+		return TEE_ERROR_BAD_FORMAT;
+
+	*seg = md + hash_off;
+	*seg_size = hash_filesz;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_mbn_reserve_region(const uint8_t *segment, size_t segment_size,
+				  size_t *offset, size_t len,
+				  const uint8_t **region, size_t *region_len)
+{
+	if (!len) {
+		*region = NULL;
+		*region_len = 0;
+		return TEE_SUCCESS;
+	}
+
+	if (len > segment_size || *offset > segment_size - len)
+		return TEE_ERROR_BAD_FORMAT;
+
+	*region = segment + *offset;
+	*region_len = len;
+	*offset += len;
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
+			 uint32_t hash_size, struct pas_mbn *out)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t oem_cert_size = 0;
+	uint32_t oem_meta_size = 0;
+	const uint8_t *seg = NULL;
+	uint32_t oem_sig_size = 0;
+	uint32_t qc_cert_size = 0;
+	uint32_t qc_meta_size = 0;
+	uint32_t qc_sig_size = 0;
+	size_t signed_size = 0;
+	uint32_t code_size = 0;
+	uint32_t version = 0;
+	size_t hdr_size = 0;
+	size_t seg_size = 0;
+	size_t cursor = 0;
+
+	if (!md || !md_size || !out || !hash_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	memset(out, 0, sizeof(*out));
+
+	res = pas_mbn_locate(md, md_size, &seg, &seg_size);
+	if (res)
+		return res;
+
+	if (seg_size < MBN_HDR_SIZE_V5)
+		return TEE_ERROR_BAD_FORMAT;
+
+	version = pas_mbn_read_u32(seg + MBN_OFF_VERSION);
+	switch (version) {
+	case PAS_MBN_VERSION_5:
+		hdr_size = MBN_HDR_SIZE_V5;
+		break;
+	case PAS_MBN_VERSION_6:
+		hdr_size = MBN_HDR_SIZE_V6;
+		break;
+	default:
+		EMSG("PAS auth: unsupported MBN version %"PRIu32, version);
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	if (seg_size < hdr_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	/*
+	 * The MBN header "code_size" field is the hash-table length in bytes,
+	 * i.e. num_entries * hash_size (one digest per program header).
+	 */
+	code_size = pas_mbn_read_u32(seg + MBN_OFF_CODE_SIZE);
+	qc_sig_size = pas_mbn_read_u32(seg + MBN_OFF_QC_SIG_SIZE);
+	qc_cert_size = pas_mbn_read_u32(seg + MBN_OFF_QC_CERT_SIZE);
+	oem_sig_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_SIG_SIZE);
+	oem_cert_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_CERT_SIZE);
+	if (version == PAS_MBN_VERSION_6) {
+		qc_meta_size = pas_mbn_read_u32(seg + MBN_OFF_QC_META_SIZE);
+		oem_meta_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_META_SIZE);
+	}
+
+	if (!code_size || code_size % hash_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	/*
+	 * Payload after the header:
+	 *   [qc_meta][oem_meta][hash table][qc_sig][qc_cert][oem_sig][oem_cert]
+	 * The signature covers the MBN header followed by
+	 * [qc_meta || oem_meta || hash table], so the signed region spans the
+	 * header and that payload from the segment start.
+	 */
+	cursor = hdr_size;
+	out->signed_region = seg;
+
+	if (ADD_OVERFLOW(qc_meta_size, oem_meta_size, &signed_size) ||
+	    ADD_OVERFLOW(signed_size, code_size, &signed_size) ||
+	    ADD_OVERFLOW(signed_size, hdr_size, &signed_size))
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (signed_size > seg_size)
+		return TEE_ERROR_BAD_FORMAT;
+	out->signed_region_size = signed_size;
+
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, qc_meta_size,
+				     &out->qti_meta, &out->qti_meta_size);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, oem_meta_size,
+				     &out->oem_meta, &out->oem_meta_size);
+	if (res)
+		return res;
+
+	out->hash_table = seg + cursor;
+	out->hash_table_size = code_size;
+	out->hash_size = hash_size;
+	out->num_entries = code_size / hash_size;
+	cursor += code_size;
+
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, qc_sig_size,
+				     &out->qti_sig, &out->qti_sig_size);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, qc_cert_size,
+				     &out->qti_certs, &out->qti_certs_size);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, oem_sig_size,
+				     &out->oem_sig, &out->oem_sig_size);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, oem_cert_size,
+				     &out->oem_certs, &out->oem_certs_size);
+	if (res)
+		return res;
+
+	out->version = version;
+
+	/* Optional trailing UIE image-encryption parameter block. */
+	if (cursor + sizeof(uint32_t) <= seg_size &&
+	    pas_mbn_read_u32(seg + cursor) == UIE_ENC_PARAM_MAGIC)
+		out->uie_encrypted = true;
+
+	return TEE_SUCCESS;
+}

--- a/ta/qcom_pas/src/pas_mbn_parser.c
+++ b/ta/qcom_pas/src/pas_mbn_parser.c
@@ -33,6 +33,15 @@ uint32_t pas_mbn_read_u32(const uint8_t *p)
 	return v;
 }
 
+uint64_t pas_mbn_read_u64(const uint8_t *p)
+{
+	uint64_t v = 0;
+
+	memcpy(&v, p, sizeof(v));
+
+	return v;
+}
+
 TEE_Result pas_mbn_locate(const uint8_t *md, size_t md_size,
 			  const uint8_t **seg, size_t *seg_size)
 {
@@ -179,6 +188,7 @@ TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
 			 uint32_t hash_size, struct pas_mbn *out)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t common_meta_size = 0;
 	uint32_t oem_cert_size = 0;
 	uint32_t oem_meta_size = 0;
 	const uint8_t *seg = NULL;
@@ -213,6 +223,9 @@ TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
 	case PAS_MBN_VERSION_6:
 		hdr_size = MBN_HDR_SIZE_V6;
 		break;
+	case PAS_MBN_VERSION_7:
+		hdr_size = MBN_HDR_SIZE_V7;
+		break;
 	default:
 		EMSG("PAS auth: unsupported MBN version %"PRIu32, version);
 		return TEE_ERROR_BAD_FORMAT;
@@ -225,14 +238,30 @@ TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
 	 * The MBN header "code_size" field is the hash-table length in bytes,
 	 * i.e. num_entries * hash_size (one digest per program header).
 	 */
-	code_size = pas_mbn_read_u32(seg + MBN_OFF_CODE_SIZE);
-	qc_sig_size = pas_mbn_read_u32(seg + MBN_OFF_QC_SIG_SIZE);
-	qc_cert_size = pas_mbn_read_u32(seg + MBN_OFF_QC_CERT_SIZE);
-	oem_sig_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_SIG_SIZE);
-	oem_cert_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_CERT_SIZE);
-	if (version == PAS_MBN_VERSION_6) {
-		qc_meta_size = pas_mbn_read_u32(seg + MBN_OFF_QC_META_SIZE);
-		oem_meta_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_META_SIZE);
+	if (version == PAS_MBN_VERSION_7) {
+		code_size = pas_mbn_read_u32(seg + MBN_OFF_V7_CODE_SIZE);
+		qc_sig_size = pas_mbn_read_u32(seg + MBN_OFF_V7_QC_SIG_SIZE);
+		qc_cert_size = pas_mbn_read_u32(seg + MBN_OFF_V7_QC_CERT_SIZE);
+		oem_sig_size = pas_mbn_read_u32(seg + MBN_OFF_V7_OEM_SIG_SIZE);
+		oem_cert_size = pas_mbn_read_u32(seg +
+						 MBN_OFF_V7_OEM_CERT_SIZE);
+		common_meta_size = pas_mbn_read_u32(seg +
+						MBN_OFF_V7_COMMON_META_SIZE);
+		qc_meta_size = pas_mbn_read_u32(seg + MBN_OFF_V7_QC_META_SIZE);
+		oem_meta_size = pas_mbn_read_u32(seg +
+						 MBN_OFF_V7_OEM_META_SIZE);
+	} else {
+		code_size = pas_mbn_read_u32(seg + MBN_OFF_CODE_SIZE);
+		qc_sig_size = pas_mbn_read_u32(seg + MBN_OFF_QC_SIG_SIZE);
+		qc_cert_size = pas_mbn_read_u32(seg + MBN_OFF_QC_CERT_SIZE);
+		oem_sig_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_SIG_SIZE);
+		oem_cert_size = pas_mbn_read_u32(seg + MBN_OFF_OEM_CERT_SIZE);
+		if (version == PAS_MBN_VERSION_6) {
+			qc_meta_size = pas_mbn_read_u32(seg +
+							MBN_OFF_QC_META_SIZE);
+			oem_meta_size = pas_mbn_read_u32(seg +
+							 MBN_OFF_OEM_META_SIZE);
+		}
 	}
 
 	if (!code_size || code_size % hash_size)
@@ -240,15 +269,17 @@ TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
 
 	/*
 	 * Payload after the header:
-	 *   [qc_meta][oem_meta][hash table][qc_sig][qc_cert][oem_sig][oem_cert]
+	 *   v6:  [qc_meta][oem_meta][hash table]...
+	 *   v7:  [common_meta][qc_meta][oem_meta][hash table]...
 	 * The signature covers the MBN header followed by
-	 * [qc_meta || oem_meta || hash table], so the signed region spans the
-	 * header and that payload from the segment start.
+	 * [(common_meta) || qc_meta || oem_meta || hash table], so the signed
+	 * region spans the header and that payload from the segment start.
 	 */
 	cursor = hdr_size;
 	out->signed_region = seg;
 
-	if (ADD_OVERFLOW(qc_meta_size, oem_meta_size, &signed_size) ||
+	if (ADD_OVERFLOW(common_meta_size, qc_meta_size, &signed_size) ||
+	    ADD_OVERFLOW(signed_size, oem_meta_size, &signed_size) ||
 	    ADD_OVERFLOW(signed_size, code_size, &signed_size) ||
 	    ADD_OVERFLOW(signed_size, hdr_size, &signed_size))
 		return TEE_ERROR_BAD_FORMAT;
@@ -257,6 +288,10 @@ TEE_Result pas_mbn_parse(const uint8_t *md, size_t md_size,
 		return TEE_ERROR_BAD_FORMAT;
 	out->signed_region_size = signed_size;
 
+	res = pas_mbn_reserve_region(seg, seg_size, &cursor, common_meta_size,
+				     &out->common_meta, &out->common_meta_size);
+	if (res)
+		return res;
 	res = pas_mbn_reserve_region(seg, seg_size, &cursor, qc_meta_size,
 				     &out->qti_meta, &out->qti_meta_size);
 	if (res)

--- a/ta/qcom_pas/src/pas_meta.c
+++ b/ta/qcom_pas/src/pas_meta.c
@@ -405,34 +405,37 @@ bool pas_meta7_flags_valid(uint32_t flags)
 	return true;
 }
 
-TEE_Result pas_meta_peek_hash_table_algo(const uint8_t *md, size_t md_size,
+TEE_Result pas_meta_peek_hash_table_algo(const uint8_t *meta_data,
+					 size_t meta_data_size,
 					 uint32_t *hash_size)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	uint32_t common_meta_size = 0;
 	const uint8_t *common_meta = NULL;
-	const uint8_t *seg = NULL;
+	const uint8_t *segment = NULL;
 	size_t common_meta_len = 0;
 	uint32_t minor = 0;
 	uint32_t algo = 0;
-	size_t seg_size = 0;
-	size_t cursor = 0;
+	size_t segment_size = 0;
+	size_t offset = 0;
 
-	if (!md || !md_size || !hash_size)
+	if (!meta_data || !meta_data_size || !hash_size)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	res = pas_mbn_locate(md, md_size, &seg, &seg_size, NULL);
+	res = pas_mbn_locate(meta_data, meta_data_size, &segment,
+			     &segment_size);
 	if (res)
 		return res;
 
-	if (seg_size < MBN_HDR_SIZE_V7)
+	if (segment_size < MBN_HDR_SIZE_V7)
 		return TEE_ERROR_BAD_FORMAT;
 
-	common_meta_size = pas_mbn_read_u32(seg +
+	common_meta_size = pas_mbn_read_u32(segment +
 					    MBN_OFF_V7_COMMON_META_SIZE);
-	cursor = MBN_HDR_SIZE_V7;
-	res = pas_mbn_take_region(seg, seg_size, &cursor, common_meta_size,
-				  &common_meta, &common_meta_len);
+	offset = MBN_HDR_SIZE_V7;
+	res = pas_mbn_reserve_region(segment, segment_size, &offset,
+				     common_meta_size, &common_meta,
+				     &common_meta_len);
 	if (res)
 		return res;
 

--- a/ta/qcom_pas/src/pas_meta.c
+++ b/ta/qcom_pas/src/pas_meta.c
@@ -65,6 +65,16 @@
 #define COMMON_META7_SIZE		0x18
 
 /*
+ * Accepted common-metadata versions: major must be 0; minor 1 additionally
+ * accepts the _ZI hash-table-algo variants over minor 0's set (both accept
+ * SHA-256/384 - the algorithms this port supports - so the two minors are
+ * otherwise equivalent here).
+ */
+#define COMMON_META7_MAJOR		0U
+#define COMMON_META7_MINOR_0		0U
+#define COMMON_META7_MINOR_1		1U
+
+/*
  * Hash-table digest algorithm identifiers carried in the v7 common
  * metadata's hash_table_algo field. Only SHA-256/384 are accepted; SHA-512
  * and every _ZI (zero-initialized-segment hashing, bit 31 set) variant fall
@@ -403,6 +413,7 @@ TEE_Result pas_meta_peek_hash_table_algo(const uint8_t *md, size_t md_size,
 	const uint8_t *common_meta = NULL;
 	const uint8_t *seg = NULL;
 	size_t common_meta_len = 0;
+	uint32_t minor = 0;
 	uint32_t algo = 0;
 	size_t seg_size = 0;
 	size_t cursor = 0;
@@ -427,6 +438,18 @@ TEE_Result pas_meta_peek_hash_table_algo(const uint8_t *md, size_t md_size,
 
 	if (!common_meta || common_meta_len < COMMON_META7_SIZE)
 		return TEE_ERROR_BAD_FORMAT;
+
+	if (pas_mbn_read_u32(common_meta + COMMON_META7_OFF_MAJOR) !=
+	    COMMON_META7_MAJOR) {
+		EMSG("PAS auth: unsupported v7 common-metadata version");
+		return TEE_ERROR_BAD_FORMAT;
+	}
+	minor = pas_mbn_read_u32(common_meta + COMMON_META7_OFF_MINOR);
+	if (minor != COMMON_META7_MINOR_0 && minor != COMMON_META7_MINOR_1) {
+		EMSG("PAS auth: unsupported v7 common-metadata minor %"PRIu32,
+		     minor);
+		return TEE_ERROR_BAD_FORMAT;
+	}
 
 	algo = pas_mbn_read_u32(common_meta + COMMON_META7_OFF_HASH_TABLE_ALGO);
 	switch (algo) {

--- a/ta/qcom_pas/src/pas_meta.c
+++ b/ta/qcom_pas/src/pas_meta.c
@@ -15,7 +15,7 @@
 
 /*
  * OEM metadata field word offsets within the metadata block
- * (little-endian 32-bit words).
+ * (little-endian 32-bit words), MBN v6 layout.
  */
 #define META_OFF_MAJOR		0
 #define META_OFF_MINOR		1
@@ -32,6 +32,49 @@
 #define META_OFF_ANTI_ROLLBACK	29
 #define META_OFF_ROOT_CERT_SEL	28
 #define META_MIN_WORDS		(META_OFF_ANTI_ROLLBACK + 1)
+
+/*
+ * MBN v7 per-signing metadata (secboot_metadata_mbnv7_type) field byte
+ * offsets - a different, packed layout from the v6 word-array above, with
+ * wider serial-number entries and fields (SOC feature/segment id, lifecycle
+ * state, OEM root-cert-hash) this port does not yet decode.
+ */
+#define META7_OFF_MAJOR			0x00
+#define META7_OFF_MINOR			0x04
+#define META7_OFF_ANTI_ROLLBACK		0x08
+#define META7_OFF_ROOT_CERT_SEL		0x0c
+#define META7_OFF_SOC_VERS		0x10
+#define META7_NUM_SOC_VERS		12
+#define META7_OFF_HW_ID			0x44
+#define META7_OFF_SERIAL_NUM		0x48
+#define META7_NUM_SERIAL_NUM		8
+#define META7_OFF_OEM_ID		0x88
+#define META7_OFF_MODEL_ID		0x8c
+#define META7_OFF_FLAGS			0xdc
+#define META7_SIZE			0xe0
+
+/*
+ * MBN v7 common metadata (secboot_common_metadata_mbnv7_type) field byte
+ * offsets, shared by both signers.
+ */
+#define COMMON_META7_OFF_MAJOR		0x00
+#define COMMON_META7_OFF_MINOR		0x04
+#define COMMON_META7_OFF_SW_ID		0x08
+#define COMMON_META7_OFF_SECONDARY_SW_ID 0x0c
+#define COMMON_META7_OFF_HASH_TABLE_ALGO 0x10
+#define COMMON_META7_SIZE		0x18
+
+/*
+ * Hash-table digest algorithm identifiers carried in the v7 common
+ * metadata's hash_table_algo field. Only SHA-256/384 are accepted; SHA-512
+ * and every _ZI (zero-initialized-segment hashing, bit 31 set) variant fall
+ * through pas_meta_peek_hash_table_algo()'s default case and are rejected -
+ * the PTA-side segment re-verification only handles SHA-256/384 digests
+ * (PAS_AUTH_CORE_MAX_HASH_SIZE = 48), and no ZI-aware consumer exists in
+ * this port.
+ */
+#define CRYPTO_HASH_ALGO_SHA256		0x2U
+#define CRYPTO_HASH_ALGO_SHA384		0x3U
 
 TEE_Result pas_meta_peek_version(const uint8_t *meta_data,
 				 size_t meta_data_size, uint32_t *version)
@@ -60,13 +103,16 @@ TEE_Result pas_meta_peek_root_cert_sel(const uint8_t *meta_data,
 				       uint32_t *root_cert_sel)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t common_meta_size = 0;
 	uint32_t oem_meta_size = 0;
 	uint32_t qc_meta_size = 0;
 	const uint8_t *oem_meta = NULL;
 	const uint8_t *qc_meta = NULL;
 	const uint8_t *segment = NULL;
+	const uint8_t *skip = NULL;
 	size_t oem_meta_len = 0;
 	size_t qc_meta_len = 0;
+	size_t skip_len = 0;
 	uint32_t version = 0;
 	size_t hdr_size = 0;
 	size_t segment_size = 0;
@@ -88,9 +134,50 @@ TEE_Result pas_meta_peek_root_cert_sel(const uint8_t *meta_data,
 		/* v5 carries no OEM metadata; caller uses the default. */
 		return TEE_ERROR_NO_DATA;
 	}
-	if (version != PAS_MBN_VERSION_6) {
+	if (version != PAS_MBN_VERSION_6 && version != PAS_MBN_VERSION_7) {
 		EMSG("PAS auth: unsupported MBN version %"PRIu32, version);
 		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	if (version == PAS_MBN_VERSION_7) {
+		hdr_size = MBN_HDR_SIZE_V7;
+		if (segment_size < hdr_size)
+			return TEE_ERROR_BAD_FORMAT;
+
+		common_meta_size = pas_mbn_read_u32(segment +
+						MBN_OFF_V7_COMMON_META_SIZE);
+		qc_meta_size = pas_mbn_read_u32(segment +
+						MBN_OFF_V7_QC_META_SIZE);
+		oem_meta_size = pas_mbn_read_u32(segment +
+						 MBN_OFF_V7_OEM_META_SIZE);
+
+		offset = hdr_size;
+		/* Skip the common and QC metadata blocks. */
+		res = pas_mbn_reserve_region(segment, segment_size, &offset,
+					     common_meta_size, &skip,
+					     &skip_len);
+		if (res)
+			return res;
+		res = pas_mbn_reserve_region(segment, segment_size, &offset,
+					     qc_meta_size, &skip, &skip_len);
+		if (res)
+			return res;
+		res = pas_mbn_reserve_region(segment, segment_size, &offset,
+					     oem_meta_size, &oem_meta,
+					     &oem_meta_len);
+		if (res)
+			return res;
+
+		if (!oem_meta)
+			return TEE_ERROR_NO_DATA;
+
+		if (oem_meta_len < META7_SIZE)
+			return TEE_ERROR_BAD_FORMAT;
+
+		*root_cert_sel = pas_mbn_read_u32(oem_meta +
+						  META7_OFF_ROOT_CERT_SEL);
+
+		return TEE_SUCCESS;
 	}
 
 	hdr_size = MBN_HDR_SIZE_V6;
@@ -222,6 +309,42 @@ TEE_Result pas_meta_get(const struct pas_mbn *hs, struct pas_meta *meta)
 	if (!hs->oem_meta || !hs->oem_meta_size)
 		return TEE_ERROR_NO_DATA;
 
+	if (hs->version == PAS_MBN_VERSION_7) {
+		if (hs->oem_meta_size < META7_SIZE)
+			return TEE_ERROR_BAD_FORMAT;
+		if (!hs->common_meta ||
+		    hs->common_meta_size < COMMON_META7_SIZE)
+			return TEE_ERROR_BAD_FORMAT;
+
+		m = hs->oem_meta;
+		meta->is_v7 = true;
+		meta->major = pas_mbn_read_u32(m + META7_OFF_MAJOR);
+		meta->minor = pas_mbn_read_u32(m + META7_OFF_MINOR);
+		meta->sw_id = pas_mbn_read_u32(hs->common_meta +
+					       COMMON_META7_OFF_SW_ID);
+		meta->secondary_sw_id =
+			pas_mbn_read_u32(hs->common_meta +
+					 COMMON_META7_OFF_SECONDARY_SW_ID);
+		meta->hw_id = pas_mbn_read_u32(m + META7_OFF_HW_ID);
+		meta->oem_id = pas_mbn_read_u32(m + META7_OFF_OEM_ID);
+		meta->model_id = pas_mbn_read_u32(m + META7_OFF_MODEL_ID);
+		meta->flags = pas_mbn_read_u32(m + META7_OFF_FLAGS);
+		for (i = 0; i < META7_NUM_SOC_VERS; i++)
+			meta->soc_vers[i] =
+				pas_mbn_read_u32(m + META7_OFF_SOC_VERS +
+						 i * sizeof(uint32_t));
+		for (i = 0; i < META7_NUM_SERIAL_NUM; i++)
+			meta->serial_num[i] =
+				pas_mbn_read_u64(m + META7_OFF_SERIAL_NUM +
+						 i * sizeof(uint64_t));
+		meta->root_cert_sel = pas_mbn_read_u32(m +
+						       META7_OFF_ROOT_CERT_SEL);
+		meta->anti_rollback = pas_mbn_read_u32(m +
+						       META7_OFF_ANTI_ROLLBACK);
+
+		return TEE_SUCCESS;
+	}
+
 	if (hs->oem_meta_size < META_MIN_WORDS * sizeof(uint32_t))
 		return TEE_ERROR_BAD_FORMAT;
 
@@ -259,6 +382,67 @@ TEE_Result pas_meta_get(const struct pas_mbn *hs, struct pas_meta *meta)
 	return TEE_SUCCESS;
 }
 
+bool pas_meta7_flags_valid(uint32_t flags)
+{
+	uint32_t shift = 0;
+
+	for (shift = 0; shift <= PAS_META7_FLAG_MAX_SHIFT; shift += 2) {
+		if (pas_meta7_flag_bit(flags, shift, true) ==
+		    pas_meta7_flag_bit(flags, shift, false))
+			return false;
+	}
+
+	return true;
+}
+
+TEE_Result pas_meta_peek_hash_table_algo(const uint8_t *md, size_t md_size,
+					 uint32_t *hash_size)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t common_meta_size = 0;
+	const uint8_t *common_meta = NULL;
+	const uint8_t *seg = NULL;
+	size_t common_meta_len = 0;
+	uint32_t algo = 0;
+	size_t seg_size = 0;
+	size_t cursor = 0;
+
+	if (!md || !md_size || !hash_size)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = pas_mbn_locate(md, md_size, &seg, &seg_size, NULL);
+	if (res)
+		return res;
+
+	if (seg_size < MBN_HDR_SIZE_V7)
+		return TEE_ERROR_BAD_FORMAT;
+
+	common_meta_size = pas_mbn_read_u32(seg +
+					    MBN_OFF_V7_COMMON_META_SIZE);
+	cursor = MBN_HDR_SIZE_V7;
+	res = pas_mbn_take_region(seg, seg_size, &cursor, common_meta_size,
+				  &common_meta, &common_meta_len);
+	if (res)
+		return res;
+
+	if (!common_meta || common_meta_len < COMMON_META7_SIZE)
+		return TEE_ERROR_BAD_FORMAT;
+
+	algo = pas_mbn_read_u32(common_meta + COMMON_META7_OFF_HASH_TABLE_ALGO);
+	switch (algo) {
+	case CRYPTO_HASH_ALGO_SHA256:
+		*hash_size = TEE_SHA256_HASH_SIZE;
+		return TEE_SUCCESS;
+	case CRYPTO_HASH_ALGO_SHA384:
+		*hash_size = TEE_SHA384_HASH_SIZE;
+		return TEE_SUCCESS;
+	default:
+		EMSG("PAS auth: unsupported v7 hash_table_algo %#"PRIx32,
+		     algo);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+}
+
 /* Zero a metadata sub-block within the signed-region copy, if present. */
 static void mask_meta_block(uint8_t *copy, size_t copy_len,
 			    const uint8_t *block, size_t block_len,
@@ -281,8 +465,8 @@ static void zero_field(uint8_t *copy, size_t copy_len, size_t off)
 		memset(copy + off, 0, sizeof(uint32_t));
 }
 
-TEE_Result pas_meta_signed_copy(const struct pas_mbn *hs,
-				uint8_t **out, size_t *out_len)
+TEE_Result pas_meta_oem_signed_copy(const struct pas_mbn *hs,
+				    uint8_t **out, size_t *out_len)
 {
 	uint8_t *copy = NULL;
 
@@ -300,10 +484,19 @@ TEE_Result pas_meta_signed_copy(const struct pas_mbn *hs,
 	 * The OEM signature is computed over the signed region with the QTI
 	 * header size fields and QTI metadata block zeroed. For an OEM-only
 	 * image these are already zero and hs->qti_meta is NULL, so the
-	 * masking is a no-op.
+	 * masking is a no-op. v7's header has a different field layout than
+	 * v5/v6 (see pas_mbn_parser_priv.h), so the size-field offsets to
+	 * zero differ by version; the metadata-block masking is
+	 * version-agnostic since it operates on the already-located
+	 * hs->qti_meta pointer.
 	 */
-	zero_field(copy, hs->signed_region_size, MBN_OFF_QC_SIG_SIZE);
-	zero_field(copy, hs->signed_region_size, MBN_OFF_QC_CERT_SIZE);
+	if (hs->version == PAS_MBN_VERSION_7) {
+		zero_field(copy, hs->signed_region_size, MBN_OFF_V7_QC_SIG_SIZE);
+		zero_field(copy, hs->signed_region_size, MBN_OFF_V7_QC_CERT_SIZE);
+	} else {
+		zero_field(copy, hs->signed_region_size, MBN_OFF_QC_SIG_SIZE);
+		zero_field(copy, hs->signed_region_size, MBN_OFF_QC_CERT_SIZE);
+	}
 	mask_meta_block(copy, hs->signed_region_size, hs->qti_meta,
 			hs->qti_meta_size, hs->signed_region);
 

--- a/ta/qcom_pas/src/pas_meta.c
+++ b/ta/qcom_pas/src/pas_meta.c
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <elf32.h>
+#include <elf64.h>
+#include <pas_mbn_parser_priv.h>
+#include <pas_meta.h>
+#include <string.h>
+#include <string_ext.h>
+#include <tee_internal_api.h>
+#include <utee_defines.h>
+#include <util.h>
+
+/*
+ * OEM metadata field word offsets within the metadata block
+ * (little-endian 32-bit words).
+ */
+#define META_OFF_MAJOR		0
+#define META_OFF_MINOR		1
+#define META_OFF_SW_ID		2
+#define META_OFF_HW_ID		3
+#define META_OFF_OEM_ID		4
+#define META_OFF_MODEL_ID	5
+#define META_OFF_SECONDARY_SW_ID 6
+#define META_OFF_FLAGS		7
+#define META_OFF_SOC_VERS	8
+#define META_NUM_SOC_VERS	12
+#define META_OFF_SERIAL_NUM	(META_OFF_SOC_VERS + META_NUM_SOC_VERS)
+#define META_NUM_SERIAL_NUM	8
+#define META_OFF_ANTI_ROLLBACK	29
+#define META_OFF_ROOT_CERT_SEL	28
+#define META_MIN_WORDS		(META_OFF_ANTI_ROLLBACK + 1)
+
+TEE_Result pas_meta_peek_version(const uint8_t *meta_data,
+				 size_t meta_data_size, uint32_t *version)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	const uint8_t *seg = NULL;
+	size_t seg_size = 0;
+
+	if (!meta_data || !meta_data_size || !version)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = pas_mbn_locate(meta_data, meta_data_size, &seg, &seg_size);
+	if (res)
+		return res;
+
+	if (seg_size < MBN_HDR_SIZE_V5)
+		return TEE_ERROR_BAD_FORMAT;
+
+	*version = pas_mbn_read_u32(seg + MBN_OFF_VERSION);
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_meta_peek_root_cert_sel(const uint8_t *meta_data,
+				       size_t meta_data_size,
+				       uint32_t *root_cert_sel)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t oem_meta_size = 0;
+	uint32_t qc_meta_size = 0;
+	const uint8_t *oem_meta = NULL;
+	const uint8_t *qc_meta = NULL;
+	const uint8_t *segment = NULL;
+	size_t oem_meta_len = 0;
+	size_t qc_meta_len = 0;
+	uint32_t version = 0;
+	size_t hdr_size = 0;
+	size_t segment_size = 0;
+	size_t offset = 0;
+
+	if (!meta_data || !meta_data_size || !root_cert_sel)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = pas_mbn_locate(meta_data, meta_data_size, &segment,
+			     &segment_size);
+	if (res)
+		return res;
+
+	if (segment_size < MBN_HDR_SIZE_V5)
+		return TEE_ERROR_BAD_FORMAT;
+
+	version = pas_mbn_read_u32(segment + MBN_OFF_VERSION);
+	if (version == PAS_MBN_VERSION_5) {
+		/* v5 carries no OEM metadata; caller uses the default. */
+		return TEE_ERROR_NO_DATA;
+	}
+	if (version != PAS_MBN_VERSION_6) {
+		EMSG("PAS auth: unsupported MBN version %"PRIu32, version);
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	hdr_size = MBN_HDR_SIZE_V6;
+	if (segment_size < hdr_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	qc_meta_size = pas_mbn_read_u32(segment + MBN_OFF_QC_META_SIZE);
+	oem_meta_size = pas_mbn_read_u32(segment + MBN_OFF_OEM_META_SIZE);
+
+	offset = hdr_size;
+	/* Skip the QC metadata; only the OEM block carries root_cert_sel. */
+	res = pas_mbn_reserve_region(segment, segment_size, &offset,
+				     qc_meta_size, &qc_meta, &qc_meta_len);
+	if (res)
+		return res;
+	res = pas_mbn_reserve_region(segment, segment_size, &offset,
+				     oem_meta_size, &oem_meta, &oem_meta_len);
+	if (res)
+		return res;
+
+	if (!oem_meta)
+		return TEE_ERROR_NO_DATA;
+
+	if (oem_meta_len < META_MIN_WORDS * sizeof(uint32_t))
+		return TEE_ERROR_BAD_FORMAT;
+
+	*root_cert_sel = pas_mbn_read_u32(oem_meta + META_OFF_ROOT_CERT_SEL *
+					      sizeof(uint32_t));
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Entry 0 digests exactly ehdr_size + phentsize * phnum from the metadata
+ * blob - the canonical entry-0 definition the signing tool commits to.
+ * Using pas_mbn_locate()'s preamble instead would silently include any
+ * padding between the phdr table and the hash segment, diverging from the
+ * signed digest.
+ */
+TEE_Result pas_meta_verify_preamble(const uint8_t *meta_data,
+				    size_t meta_data_size,
+				    const uint8_t *hash_table,
+				    uint32_t hash_size)
+{
+	uint8_t dgst[TEE_SHA384_HASH_SIZE] = { };
+	TEE_OperationHandle op = TEE_HANDLE_NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t dgst_len = sizeof(dgst);
+	size_t ehdr_size = 0;
+	size_t phentsize = 0;
+	size_t phnum = 0;
+	size_t hdr_len = 0;
+	uint32_t algo = 0;
+
+	if (!meta_data || !meta_data_size || !hash_table)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	switch (hash_size) {
+	case TEE_SHA256_HASH_SIZE:
+		algo = TEE_ALG_SHA256;
+		break;
+	case TEE_SHA384_HASH_SIZE:
+		algo = TEE_ALG_SHA384;
+		break;
+	default:
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+
+	if (meta_data_size < EI_NIDENT)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (meta_data[EI_MAG0] != ELFMAG0 || meta_data[EI_MAG1] != ELFMAG1 ||
+	    meta_data[EI_MAG2] != ELFMAG2 || meta_data[EI_MAG3] != ELFMAG3)
+		return TEE_ERROR_BAD_FORMAT;
+
+	if (meta_data[EI_CLASS] == ELFCLASS64) {
+		const Elf64_Ehdr *ehdr = (const void *)meta_data;
+
+		if (meta_data_size < sizeof(*ehdr))
+			return TEE_ERROR_BAD_FORMAT;
+		ehdr_size = ehdr->e_ehsize;
+		phentsize = ehdr->e_phentsize;
+		phnum = ehdr->e_phnum;
+	} else if (meta_data[EI_CLASS] == ELFCLASS32) {
+		const Elf32_Ehdr *ehdr = (const void *)meta_data;
+
+		if (meta_data_size < sizeof(*ehdr))
+			return TEE_ERROR_BAD_FORMAT;
+		ehdr_size = ehdr->e_ehsize;
+		phentsize = ehdr->e_phentsize;
+		phnum = ehdr->e_phnum;
+	} else {
+		return TEE_ERROR_BAD_FORMAT;
+	}
+
+	if (MUL_OVERFLOW(phentsize, phnum, &hdr_len) ||
+	    ADD_OVERFLOW(hdr_len, ehdr_size, &hdr_len) ||
+	    hdr_len > meta_data_size)
+		return TEE_ERROR_BAD_FORMAT;
+
+	res = TEE_AllocateOperation(&op, algo, TEE_MODE_DIGEST, 0);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = TEE_DigestDoFinal(op, meta_data, hdr_len, dgst, &dgst_len);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	if (dgst_len != hash_size ||
+	    consttime_memcmp(dgst, hash_table, hash_size) != 0)
+		res = TEE_ERROR_SECURITY;
+	else
+		res = TEE_SUCCESS;
+out:
+	TEE_FreeOperation(op);
+	memzero_explicit(dgst, sizeof(dgst));
+
+	return res;
+}
+
+TEE_Result pas_meta_get(const struct pas_mbn *hs, struct pas_meta *meta)
+{
+	const uint8_t *m = NULL;
+	size_t i = 0;
+
+	if (!hs || !meta)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	if (!hs->oem_meta || !hs->oem_meta_size)
+		return TEE_ERROR_NO_DATA;
+
+	if (hs->oem_meta_size < META_MIN_WORDS * sizeof(uint32_t))
+		return TEE_ERROR_BAD_FORMAT;
+
+	m = hs->oem_meta;
+	meta->major = pas_mbn_read_u32(m + META_OFF_MAJOR *
+					   sizeof(uint32_t));
+	meta->minor = pas_mbn_read_u32(m + META_OFF_MINOR *
+					   sizeof(uint32_t));
+	meta->sw_id = pas_mbn_read_u32(m + META_OFF_SW_ID *
+					   sizeof(uint32_t));
+	meta->hw_id = pas_mbn_read_u32(m + META_OFF_HW_ID *
+					   sizeof(uint32_t));
+	meta->oem_id = pas_mbn_read_u32(m + META_OFF_OEM_ID *
+					    sizeof(uint32_t));
+	meta->model_id = pas_mbn_read_u32(m + META_OFF_MODEL_ID *
+					      sizeof(uint32_t));
+	meta->secondary_sw_id = pas_mbn_read_u32(m +
+						     META_OFF_SECONDARY_SW_ID *
+						     sizeof(uint32_t));
+	meta->flags = pas_mbn_read_u32(m + META_OFF_FLAGS *
+					   sizeof(uint32_t));
+	for (i = 0; i < META_NUM_SOC_VERS; i++)
+		meta->soc_vers[i] = pas_mbn_read_u32(m + (META_OFF_SOC_VERS +
+							  i) *
+						     sizeof(uint32_t));
+	for (i = 0; i < META_NUM_SERIAL_NUM; i++)
+		meta->serial_num[i] = pas_mbn_read_u32(m +
+						       (META_OFF_SERIAL_NUM +
+							i) * sizeof(uint32_t));
+	meta->root_cert_sel = pas_mbn_read_u32(m + META_OFF_ROOT_CERT_SEL *
+						   sizeof(uint32_t));
+	meta->anti_rollback = pas_mbn_read_u32(m + META_OFF_ANTI_ROLLBACK *
+						   sizeof(uint32_t));
+
+	return TEE_SUCCESS;
+}
+
+/* Zero a metadata sub-block within the signed-region copy, if present. */
+static void mask_meta_block(uint8_t *copy, size_t copy_len,
+			    const uint8_t *block, size_t block_len,
+			    const uint8_t *base)
+{
+	size_t off = 0;
+
+	if (!block || !block_len)
+		return;
+
+	off = (size_t)(block - base);
+	if (off < copy_len && block_len <= copy_len - off)
+		memset(copy + off, 0, block_len);
+}
+
+/* Zero a header uint32_t field at @off within the signed-region copy. */
+static void zero_field(uint8_t *copy, size_t copy_len, size_t off)
+{
+	if (off + sizeof(uint32_t) <= copy_len)
+		memset(copy + off, 0, sizeof(uint32_t));
+}
+
+TEE_Result pas_meta_signed_copy(const struct pas_mbn *hs,
+				uint8_t **out, size_t *out_len)
+{
+	uint8_t *copy = NULL;
+
+	if (!hs || !hs->signed_region || !hs->signed_region_size || !out ||
+	    !out_len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	copy = TEE_Malloc(hs->signed_region_size, TEE_MALLOC_FILL_ZERO);
+	if (!copy)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	memcpy(copy, hs->signed_region, hs->signed_region_size);
+
+	/*
+	 * The OEM signature is computed over the signed region with the QTI
+	 * header size fields and QTI metadata block zeroed. For an OEM-only
+	 * image these are already zero and hs->qti_meta is NULL, so the
+	 * masking is a no-op.
+	 */
+	zero_field(copy, hs->signed_region_size, MBN_OFF_QC_SIG_SIZE);
+	zero_field(copy, hs->signed_region_size, MBN_OFF_QC_CERT_SIZE);
+	mask_meta_block(copy, hs->signed_region_size, hs->qti_meta,
+			hs->qti_meta_size, hs->signed_region);
+
+	*out = copy;
+	*out_len = hs->signed_region_size;
+
+	return TEE_SUCCESS;
+}

--- a/ta/qcom_pas/src/pas_policy.c
+++ b/ta/qcom_pas/src/pas_policy.c
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <pas_policy.h>
+#include <tee_api_types.h>
+#include <util.h>
+
+/*
+ * PAS remote-processor identifiers (the pas_id passed by the REE). These are
+ * the architectural Qualcomm PIL processor IDs.
+ */
+#define PAS_ID_QDSP6		1	/* ADSP / LPASS */
+#define PAS_ID_WPSS		6	/* WLAN/BT */
+#define PAS_ID_VENUS		9	/* video: VENUS/IRIS */
+#define PAS_ID_TURING		18	/* CDSP / CDSP0 */
+#define PAS_ID_TURING1		30	/* CDSP1 */
+#define PAS_ID_GPDSP0		39
+#define PAS_ID_GPDSP1		40
+
+/*
+ * Image software types (SW_ID). The image's signed metadata carries one of
+ * these and it must equal the value bound to the peripheral being brought
+ * up.
+ */
+#define SECBOOT_ADSP_SW_TYPE	0x04
+#define SECBOOT_WCNSS_SW_TYPE	0x0D
+#define SECBOOT_VIDEO_SW_TYPE	0x0E
+#define SECBOOT_CDSP_SW_TYPE	0x17
+#define SECBOOT_CDSP1_SW_TYPE	0x44
+#define SECBOOT_GPDSP0_SW_TYPE	0x58
+#define SECBOOT_GPDSP1_SW_TYPE	0x5A
+
+/* pas_id -> expected SW_ID for these targets. */
+static const struct {
+	uint32_t pas_id;
+	uint32_t swid;
+} pas_swid_map[] = {
+	{ PAS_ID_QDSP6, SECBOOT_ADSP_SW_TYPE },
+	{ PAS_ID_WPSS, SECBOOT_WCNSS_SW_TYPE },
+	{ PAS_ID_VENUS, SECBOOT_VIDEO_SW_TYPE },
+	{ PAS_ID_TURING, SECBOOT_CDSP_SW_TYPE },
+	{ PAS_ID_TURING1, SECBOOT_CDSP1_SW_TYPE },
+	{ PAS_ID_GPDSP0, SECBOOT_GPDSP0_SW_TYPE },
+	{ PAS_ID_GPDSP1, SECBOOT_GPDSP1_SW_TYPE },
+};
+
+TEE_Result pas_policy_expected_swid(uint32_t pas_id, uint32_t *swid)
+{
+	size_t i = 0;
+
+	if (!swid)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	for (i = 0; i < ARRAY_SIZE(pas_swid_map); i++) {
+		if (pas_swid_map[i].pas_id == pas_id) {
+			*swid = pas_swid_map[i].swid;
+			return TEE_SUCCESS;
+		}
+	}
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+enum pas_sign_authority pas_policy_signer(uint32_t swid __unused)
+{
+	/* Every SW_ID this port supports is OEM-signed only. */
+	return PAS_OEM_SIGNED;
+}

--- a/ta/qcom_pas/src/pas_sig.c
+++ b/ta/qcom_pas/src/pas_sig.c
@@ -1,0 +1,572 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <mbedtls/asn1.h>
+#include <mbedtls/md.h>
+#include <mbedtls/oid.h>
+#include <mbedtls/pk.h>
+#include <mbedtls/x509_crt.h>
+#include <pas_sig.h>
+#include <string.h>
+#include <string_ext.h>
+#include <tee_internal_api.h>
+#include <tee_internal_api_extensions.h>
+#include <util.h>
+#include <utee_defines.h>
+
+/* DER identifier octet for a constructed SEQUENCE (0x30). */
+#define DER_SEQUENCE_TAG \
+	(MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE)
+
+static TEE_Result md_from_tee(uint32_t hash_algo, mbedtls_md_type_t *md)
+{
+	switch (hash_algo) {
+	case TEE_ALG_SHA256:
+		*md = MBEDTLS_MD_SHA256;
+		return TEE_SUCCESS;
+	case TEE_ALG_SHA384:
+		*md = MBEDTLS_MD_SHA384;
+		return TEE_SUCCESS;
+	default:
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+}
+
+static TEE_Result digest(uint32_t hash_algo, const uint8_t *msg, size_t msg_len,
+			 uint8_t *out, size_t *out_len)
+{
+	TEE_OperationHandle op = TEE_HANDLE_NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = TEE_AllocateOperation(&op, hash_algo, TEE_MODE_DIGEST, 0);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = TEE_DigestDoFinal(op, msg, msg_len, out, out_len);
+
+	TEE_FreeOperation(op);
+
+	return res;
+}
+
+/*
+ * Certificate policy for image-signing chains:
+ *   - signature MDs restricted to SHA-256 / SHA-384
+ *   - public keys restricted to ECDSA
+ *   - ECDSA curve restricted to NIST P-384
+ *   - notBefore/notAfter are NOT enforced (TZ has no trusted RTC)
+ * Chain-structure checks (leaf !CA, intermediate CA=TRUE, pathlen) are done
+ * in check_chain_constraints().
+ */
+static const mbedtls_x509_crt_profile pas_crt_profile = {
+	.allowed_mds = MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA256) |
+		       MBEDTLS_X509_ID_FLAG(MBEDTLS_MD_SHA384),
+	.allowed_pks = MBEDTLS_X509_ID_FLAG(MBEDTLS_PK_ECDSA) |
+		       MBEDTLS_X509_ID_FLAG(MBEDTLS_PK_ECKEY),
+	.allowed_curves = MBEDTLS_X509_ID_FLAG(MBEDTLS_ECP_DP_SECP384R1),
+};
+
+/*
+ * Require the leaf to carry the code-signing Extended Key Usage OID when
+ * @enforced is set. The caller derives @enforced from the OEM_CONFIG2
+ * EKU_ENFORCEMENT_EN fuse. mbedTLS treats an absent EKU extension as "no
+ * restriction" and would otherwise pass a leaf that never asserts the OID;
+ * require the extension to be present when EKU enforcement is enabled.
+ */
+static TEE_Result check_eku(const mbedtls_x509_crt *leaf, bool enforced)
+{
+	size_t oid_len = MBEDTLS_OID_SIZE(MBEDTLS_OID_CODE_SIGNING);
+	int ext = MBEDTLS_X509_EXT_EXTENDED_KEY_USAGE;
+
+	if (!enforced)
+		return TEE_SUCCESS;
+
+	if (!mbedtls_x509_crt_has_ext_type(leaf, ext)) {
+		EMSG("PAS auth: leaf cert has no EKU extension");
+		return TEE_ERROR_SECURITY;
+	}
+
+	if (mbedtls_x509_crt_check_extended_key_usage(leaf,
+						      MBEDTLS_OID_CODE_SIGNING,
+						      oid_len)) {
+		EMSG("PAS auth: leaf cert missing code-signing EKU");
+		return TEE_ERROR_SECURITY;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Enforce structural constraints across the parsed chain: the leaf must
+ * not assert CA=TRUE, every issuer (non-leaf) must be a CA, and the leaf
+ * must carry a KeyUsage extension asserting digitalSignature. mbedTLS
+ * treats an absent KeyUsage extension as "no restriction" and would
+ * otherwise pass a leaf that never asserts the bit; require the extension
+ * to be present. The pathLenConstraint is validated inside
+ * mbedtls_x509_crt_verify_with_profile() during RFC 5280 path building.
+ * Uses the public ca_istrue/check_key_usage accessors (the underlying
+ * fields are private).
+ *
+ * @eku_enforced additionally requires the leaf to carry the code-signing
+ * Extended Key Usage OID, gated on the OEM_CONFIG2 EKU_ENFORCEMENT_EN fuse.
+ */
+static TEE_Result check_chain_constraints(const mbedtls_x509_crt *leaf,
+					  bool eku_enforced)
+{
+	const mbedtls_x509_crt *crt = NULL;
+	size_t depth = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t ku = MBEDTLS_X509_KU_DIGITAL_SIGNATURE;
+
+	if (!mbedtls_x509_crt_has_ext_type(leaf, MBEDTLS_X509_EXT_KEY_USAGE)) {
+		EMSG("PAS auth: leaf cert has no KeyUsage extension");
+		return TEE_ERROR_SECURITY;
+	}
+
+	if (mbedtls_x509_crt_check_key_usage(leaf, ku)) {
+		EMSG("PAS auth: leaf cert missing digitalSignature KeyUsage");
+		return TEE_ERROR_SECURITY;
+	}
+
+	res = check_eku(leaf, eku_enforced);
+	if (res)
+		return res;
+
+	for (crt = leaf; crt; crt = crt->next, depth++) {
+		int ca = mbedtls_x509_crt_get_ca_istrue(crt);
+
+		if (ca < 0) {
+			EMSG("PAS auth: cannot read CA flag at depth %zu",
+			     depth);
+			return TEE_ERROR_SECURITY;
+		}
+
+		if (crt == leaf) {
+			if (ca) {
+				EMSG("PAS auth: leaf cert asserts CA");
+				return TEE_ERROR_SECURITY;
+			}
+			continue;
+		}
+
+		if (!ca) {
+			EMSG("PAS auth: issuer at depth %zu is not a CA",
+			     depth);
+			return TEE_ERROR_SECURITY;
+		}
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Compare two mbedTLS ASN.1 buffers for equality (same length and bytes).
+ * Absent buffers (len == 0) never compare equal - callers gate on presence
+ * before calling this.
+ */
+static bool asn1_buf_eq(const mbedtls_x509_buf *a, const mbedtls_x509_buf *b)
+{
+	return a->len && a->len == b->len && !memcmp(a->p, b->p, a->len);
+}
+
+/*
+ * Verify that @issuer actually issued @subject: beyond the subject/issuer
+ * name match mbedTLS's own chain-verify already performs, cross-check the
+ * subject's Authority Key Identifier (key id + serial number, when present)
+ * against the issuer's Subject Key Identifier and certificate serial
+ * number. Name-only matching (what mbedTLS's parent search does on its own)
+ * cannot distinguish two issuer candidates that share a subject DN but hold
+ * different keys; AKID/SKID/serial linkage disambiguates that case.
+ */
+static TEE_Result check_issuer_linkage(const mbedtls_x509_crt *issuer,
+				       const mbedtls_x509_crt *subject)
+{
+	const mbedtls_x509_authority *akid = &subject->authority_key_id;
+
+	if (akid->keyIdentifier.len &&
+	    issuer->subject_key_id.len &&
+	    !asn1_buf_eq(&akid->keyIdentifier, &issuer->subject_key_id)) {
+		EMSG("PAS auth: AKID/SKID mismatch in cert chain");
+		return TEE_ERROR_SECURITY;
+	}
+
+	if (akid->authorityCertSerialNumber.len &&
+	    !asn1_buf_eq(&akid->authorityCertSerialNumber, &issuer->serial)) {
+		EMSG("PAS auth: AKID serial mismatch in cert chain");
+		return TEE_ERROR_SECURITY;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Chain-length bounds applied before any further validation. A chain carries
+ * a leaf, an optional intermediate, and one or more roots; the non-root
+ * levels are bounded by PAS_MAX_CERT_CHAIN_LEVEL and the roots by
+ * PAS_MAX_NUM_ROOT_CERTS.
+ */
+#define PAS_MIN_NUM_CERTS	2U
+#define PAS_MAX_CERT_CHAIN_LEVEL 3U
+#define PAS_MAX_NUM_ROOT_CERTS	4U
+#define PAS_TOTAL_MAX_CERTS	(PAS_MAX_NUM_ROOT_CERTS + \
+				 PAS_MAX_CERT_CHAIN_LEVEL - 1)
+
+TEE_Result pas_sig_verify_cert_chain(const uint8_t *chain_der,
+				     size_t chain_der_len, bool eku_enforced,
+				     uint32_t num_roots,
+				     uint32_t root_cert_sel,
+				     const uint8_t **leaf_der,
+				     size_t *leaf_der_len,
+				     const uint8_t **roots_der,
+				     size_t *roots_der_len)
+{
+	TEE_Result res = TEE_ERROR_SECURITY;
+	const mbedtls_x509_crt *crt = NULL;
+	mbedtls_x509_crt *sel_root = NULL;
+	mbedtls_x509_crt *leaf = NULL;
+	mbedtls_x509_crt chain = { };
+	mbedtls_x509_crt trust = { };
+	size_t num_prefix = 0;
+	size_t sel_index = 0;
+	size_t roots_off = 0;
+	size_t num_certs = 0;
+	uint32_t flags = 0;
+	size_t off = 0;
+	size_t i = 0;
+	int rc = 0;
+
+	if (!chain_der || !chain_der_len || !leaf_der || !leaf_der_len ||
+	    !num_roots || num_roots > PAS_MAX_NUM_ROOT_CERTS ||
+	    root_cert_sel >= num_roots)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mbedtls_x509_crt_init(&chain);
+	mbedtls_x509_crt_init(&trust);
+
+	/*
+	 * The certificate region is concatenated DER certificates followed by
+	 * 0xFF padding: leaf and optional intermediate first, then @num_roots
+	 * provisioned roots. mbedtls_x509_crt_parse_der() consumes exactly one
+	 * certificate per call, so walk the buffer certificate by certificate,
+	 * stopping at the first byte that is not a DER SEQUENCE (the padding),
+	 * and track each certificate's byte offset for the pointers handed
+	 * back to the caller.
+	 */
+	while (off < chain_der_len && chain_der[off] == DER_SEQUENCE_TAG) {
+		mbedtls_x509_crt *added = NULL;
+
+		if (num_certs >= PAS_TOTAL_MAX_CERTS)
+			break;
+
+		if (mbedtls_x509_crt_parse_der(&chain, chain_der + off,
+					       chain_der_len - off)) {
+			EMSG("PAS auth: cert %zu parse failed", num_certs);
+			goto out;
+		}
+
+		/* The just-parsed certificate is the last one in the list. */
+		added = &chain;
+		while (added->next)
+			added = added->next;
+
+		off += added->raw.len;
+		num_certs++;
+	}
+
+	/*
+	 * Everything from the end of the last parsed certificate to the end
+	 * of the buffer must be 0xFF padding. A byte here that failed the
+	 * DER-SEQUENCE scan above for any other reason (corruption, a
+	 * truncated cert, or attacker-controlled filler) is rejected here
+	 * instead of being silently ignored.
+	 */
+	for (i = off; i < chain_der_len; i++) {
+		if (chain_der[i] != 0xFF) {
+			EMSG("PAS auth: non-0xFF byte at chain offset %zu", i);
+			goto out;
+		}
+	}
+
+	/*
+	 * The non-root levels (leaf, optional intermediate) must satisfy the
+	 * conventional chain bounds; the roots sit on top of them.
+	 */
+	if (num_certs <= num_roots) {
+		EMSG("PAS auth: chain has %zu certs, need > %"PRIu32" roots",
+		     num_certs, num_roots);
+		goto out;
+	}
+	num_prefix = num_certs - num_roots;
+	if (num_prefix < (PAS_MIN_NUM_CERTS - 1) ||
+	    num_prefix > (PAS_MAX_CERT_CHAIN_LEVEL - 1)) {
+		EMSG("PAS auth: chain has %zu non-root certs, want [%u, %u]",
+		     num_prefix, PAS_MIN_NUM_CERTS - 1,
+		     PAS_MAX_CERT_CHAIN_LEVEL - 1);
+		goto out;
+	}
+
+	leaf = &chain;
+
+	/*
+	 * Locate the selected root (prefix certs, then root_cert_sel roots) and
+	 * the byte offset where the root region begins (after the prefix).
+	 */
+	sel_index = num_prefix + root_cert_sel;
+	for (crt = &chain, i = 0; crt; crt = crt->next, i++) {
+		if (i < num_prefix)
+			roots_off += crt->raw.len;
+		if (i == sel_index)
+			sel_root = (mbedtls_x509_crt *)crt;
+	}
+	if (!sel_root) {
+		EMSG("PAS auth: selected root %zu not present", sel_index);
+		goto out;
+	}
+
+	/*
+	 * Verify internal chain integrity up to the selected root: parse it
+	 * into a standalone trust store so mbedTLS matches it as the anchor
+	 * without walking into the other roots in the chain list. Root-of-trust
+	 * binding against the fuse digest happens later in
+	 * pas_sig_check_root_of_trust().
+	 */
+	if (mbedtls_x509_crt_parse_der(&trust, sel_root->raw.p,
+				       sel_root->raw.len)) {
+		EMSG("PAS auth: root cert re-parse failed");
+		goto out;
+	}
+
+	rc = mbedtls_x509_crt_verify_with_profile(leaf, &trust, NULL,
+						  &pas_crt_profile, NULL,
+						  &flags, NULL, NULL);
+	/*
+	 * Certificate validity dates are not checked (no trusted RTC), so an
+	 * expired or not-yet-valid cert must not fail authentication. Clear
+	 * those flags and re-evaluate; any other flag is fatal.
+	 */
+	flags &= ~(uint32_t)(MBEDTLS_X509_BADCERT_EXPIRED |
+			     MBEDTLS_X509_BADCERT_FUTURE);
+	if (rc && flags) {
+		EMSG("PAS auth: cert chain verify failed (%#"PRIx32")", flags);
+		goto out;
+	}
+
+	res = check_chain_constraints(leaf, eku_enforced);
+	if (res)
+		goto out;
+
+	/*
+	 * Cross-check issuer linkage across the prefix (leaf up to the last
+	 * intermediate), then from the last prefix cert to the selected root.
+	 * crt->next cannot be used to walk this last link: with multiple
+	 * roots it points at whichever root sits next in the buffer, not
+	 * necessarily the selected one.
+	 */
+	crt = leaf;
+	for (i = 0; i + 1 < num_prefix; i++) {
+		res = check_issuer_linkage(crt->next, crt);
+		if (res)
+			goto out;
+		crt = crt->next;
+	}
+	res = check_issuer_linkage(sel_root, crt);
+	if (res)
+		goto out;
+
+	/*
+	 * mbedtls_x509_crt_parse_der() copies DER into its own allocation;
+	 * raw.p is invalid after free. Hand out pointers back into chain_der:
+	 * the leaf starts at chain_der[0]; the root region spans all roots,
+	 * from the end of the prefix to the end of the last parsed cert.
+	 */
+	if (roots_off > off || off > chain_der_len ||
+	    leaf->raw.len > chain_der_len) {
+		EMSG("PAS auth: cert DER length exceeds chain buffer");
+		res = TEE_ERROR_SECURITY;
+		goto out;
+	}
+
+	*leaf_der = chain_der;
+	*leaf_der_len = leaf->raw.len;
+	if (roots_der)
+		*roots_der = chain_der + roots_off;
+	if (roots_der_len)
+		*roots_der_len = off - roots_off;
+
+	res = TEE_SUCCESS;
+out:
+	mbedtls_x509_crt_free(&trust);
+	mbedtls_x509_crt_free(&chain);
+
+	return res;
+}
+
+static TEE_Result pas_sig_verify_hash(uint32_t hash_algo,
+				      const uint8_t *data, size_t data_len,
+				      const uint8_t *expected,
+				      size_t hash_size)
+{
+	uint8_t dgst[PAS_AUTH_MAX_HASH_SIZE] = { };
+	TEE_OperationHandle op = TEE_HANDLE_NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	size_t len = sizeof(dgst);
+
+	if (!data || !expected || !hash_size || hash_size > sizeof(dgst))
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = TEE_AllocateOperation(&op, hash_algo, TEE_MODE_DIGEST, 0);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = TEE_DigestDoFinal(op, data, data_len, dgst, &len);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	if (len != hash_size) {
+		res = TEE_ERROR_SECURITY;
+		goto out;
+	}
+
+	if (consttime_memcmp(dgst, expected, hash_size) != 0)
+		res = TEE_ERROR_SECURITY;
+	else
+		res = TEE_SUCCESS;
+out:
+	TEE_FreeOperation(op);
+	memzero_explicit(dgst, sizeof(dgst));
+
+	return res;
+}
+
+TEE_Result pas_sig_check_root_of_trust(uint32_t hash_algo, size_t hash_size,
+				       const uint8_t *root_der,
+				       size_t root_der_len,
+				       const uint8_t *expected)
+{
+	if (!root_der || !root_der_len || !expected)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	return pas_sig_verify_hash(hash_algo, root_der, root_der_len,
+				   expected, hash_size);
+}
+
+TEE_Result pas_sig_algo_from_leaf(const uint8_t *leaf_der,
+				  size_t leaf_der_len, uint32_t *sig_algo,
+				  uint32_t *hash_algo)
+{
+	mbedtls_pk_type_t pk_type = MBEDTLS_PK_NONE;
+	TEE_Result res = TEE_ERROR_SECURITY;
+	mbedtls_x509_crt leaf = { };
+
+	if (!leaf_der || !leaf_der_len || !sig_algo || !hash_algo)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	mbedtls_x509_crt_init(&leaf);
+	if (mbedtls_x509_crt_parse_der(&leaf, leaf_der, leaf_der_len)) {
+		EMSG("PAS auth: leaf cert parse failed");
+		goto out;
+	}
+
+	pk_type = mbedtls_pk_get_type(&leaf.pk);
+	switch (pk_type) {
+	case MBEDTLS_PK_ECKEY:
+	case MBEDTLS_PK_ECDSA:
+		*hash_algo = TEE_ALG_SHA384;
+		*sig_algo = TEE_ALG_ECDSA_SHA384;
+		res = TEE_SUCCESS;
+		break;
+	default:
+		EMSG("PAS auth: unsupported key type %d", pk_type);
+		res = TEE_ERROR_NOT_SUPPORTED;
+		break;
+	}
+out:
+	mbedtls_x509_crt_free(&leaf);
+
+	return res;
+}
+
+/*
+ * The signature field in the hash segment is a fixed-size reservation, so the
+ * actual signature is shorter than @field_len and the remainder is padding.
+ * mbedTLS rejects trailing bytes after the signature, so derive the true
+ * length: an ECDSA signature is a DER SEQUENCE whose encoded length gives the
+ * exact size.
+ */
+static size_t ecdsa_der_sig_len(const uint8_t *sig, size_t field_len)
+{
+	size_t len = 0;
+
+	if (field_len < 2 || sig[0] != DER_SEQUENCE_TAG)
+		return field_len;
+
+	if (sig[1] < 0x80) {
+		/* Short-form length: one length byte follows the tag. */
+		len = (size_t)sig[1] + 2;
+	} else if (sig[1] == 0x81 && field_len >= 3) {
+		/* Long-form, one length byte. */
+		len = (size_t)sig[2] + 3;
+	} else {
+		return field_len;
+	}
+
+	return len <= field_len ? len : field_len;
+}
+
+TEE_Result pas_sig_verify_signature(uint32_t sig_algo, uint32_t hash_algo,
+				    const uint8_t *leaf_der,
+				    size_t leaf_der_len,
+				    const uint8_t *msg, size_t msg_len,
+				    const uint8_t *sig, size_t sig_len)
+{
+	uint8_t dgst[PAS_AUTH_MAX_HASH_SIZE] = { };
+	mbedtls_md_type_t md = MBEDTLS_MD_NONE;
+	TEE_Result res = TEE_ERROR_SECURITY;
+	size_t dgst_len = sizeof(dgst);
+	mbedtls_x509_crt leaf = { };
+	size_t actual_sig_len = 0;
+	int rc = 0;
+
+	if (!leaf_der || !leaf_der_len || !msg || !msg_len || !sig || !sig_len)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	res = md_from_tee(hash_algo, &md);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = digest(hash_algo, msg, msg_len, dgst, &dgst_len);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	mbedtls_x509_crt_init(&leaf);
+	if (mbedtls_x509_crt_parse_der(&leaf, leaf_der, leaf_der_len)) {
+		res = TEE_ERROR_SECURITY;
+		goto out;
+	}
+
+	switch (sig_algo) {
+	case TEE_ALG_ECDSA_SHA384:
+		actual_sig_len = ecdsa_der_sig_len(sig, sig_len);
+		rc = mbedtls_pk_verify(&leaf.pk, md, dgst, dgst_len,
+				       sig, actual_sig_len);
+		break;
+	default:
+		res = TEE_ERROR_NOT_SUPPORTED;
+		goto out;
+	}
+
+	if (rc) {
+		EMSG("PAS auth: signature verify failed (%d)", rc);
+		res = TEE_ERROR_SECURITY;
+		goto out;
+	}
+
+	res = TEE_SUCCESS;
+out:
+	mbedtls_x509_crt_free(&leaf);
+	memzero_explicit(dgst, sizeof(dgst));
+
+	return res;
+}

--- a/ta/qcom_pas/src/pas_sig_auth.c
+++ b/ta/qcom_pas/src/pas_sig_auth.c
@@ -1,0 +1,554 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+/*
+ * Signature-authentication backend for the PAS TA. Built only when
+ * CFG_QCOM_PAS_AUTH is enabled (see pas_sig_auth.h).
+ */
+
+#include <config.h>
+#include <pas_sig.h>
+#include <pas_fuse.h>
+#include <pas_mbn_parser.h>
+#include <pas_meta.h>
+#include <pas_policy.h>
+#include <pta_qcom_fuse.h>
+#include <pas_sig_auth.h>
+#include <qcom_pas_priv.h>
+#include <string_ext.h>
+#include <tee_internal_api.h>
+#include <utee_defines.h>
+#include <util.h>
+
+/*
+ * Accepted metadata major versions: V0 (0) and V1 (1); minor must be 0.
+ */
+#define SECBOOT_METADATA_MAJOR_V0	0U
+#define SECBOOT_METADATA_MAJOR_V1	1U
+#define SECBOOT_METADATA_MINOR		0U
+
+/*
+ * Reject metadata whose major/minor version falls outside the accepted set.
+ * Must be called after signature verification so the metadata is authenticated.
+ */
+static TEE_Result check_metadata_version(const struct pas_mbn *hs)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct pas_meta meta = { };
+
+	res = pas_meta_get(hs, &meta);
+	if (res == TEE_ERROR_NO_DATA)
+		return TEE_SUCCESS; /* No OEM metadata (v5): nothing to check */
+	if (res) {
+		EMSG("PAS auth: bad OEM metadata in version check");
+		return res;
+	}
+
+	if ((meta.major == SECBOOT_METADATA_MAJOR_V0 ||
+	     meta.major == SECBOOT_METADATA_MAJOR_V1) &&
+	    meta.minor == SECBOOT_METADATA_MINOR)
+		return TEE_SUCCESS;
+
+	EMSG("PAS auth: unsupported metadata version %"PRIu32".%"PRIu32,
+	     meta.major, meta.minor);
+	return TEE_ERROR_SECURITY;
+}
+
+/*
+ * Bind the signed image to the peripheral being brought up: the metadata
+ * SW_ID must match the value the platform assigns to this pas_id, so a
+ * validly-signed image for one subsystem cannot be loaded onto another.
+ * The metadata lives inside the already signature-verified region.
+ */
+static TEE_Result check_sw_binding(const struct pas_mbn *hs, uint32_t pas_id)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	struct pas_meta meta = { };
+	uint32_t expected = 0;
+
+	res = pas_meta_get(hs, &meta);
+	if (res == TEE_ERROR_NO_DATA) {
+		/* No OEM metadata (MBN v5): nothing to bind. */
+		return TEE_SUCCESS;
+	}
+	if (res) {
+		EMSG("PAS auth: bad OEM metadata");
+		return res;
+	}
+
+	res = pas_policy_expected_swid(pas_id, &expected);
+	if (res) {
+		EMSG("PAS auth: no SW_ID binding for pas_id %"PRIu32, pas_id);
+		return res;
+	}
+
+	if (meta.sw_id != expected) {
+		EMSG("PAS auth: SW_ID got %#"PRIx32" want %#"PRIx32,
+		     meta.sw_id, expected);
+		return TEE_ERROR_SECURITY;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * 2-bit option field value at @shift within @flags. Valid values are 0-2
+ * (disable/enable/enable-with-serial-match) for DEBUG, root revoke/activate
+ * and UIE key switch; 3 is reserved and never valid.
+ */
+static uint32_t pas_meta_option(uint32_t flags, uint32_t shift)
+{
+	return (flags >> shift) & PAS_META_OPTION_MASK;
+}
+
+/*
+ * True if the 2-bit option field at @shift within @flags requests its
+ * SN-gated enable value.
+ */
+static bool pas_meta_option_sn_gated(uint32_t flags, uint32_t shift)
+{
+	return pas_meta_option(flags, shift) == PAS_META_OPTION_ENABLE_SN;
+}
+
+/*
+ * Reject metadata whose 2-bit option fields carry the reserved value 3.
+ */
+static TEE_Result check_metadata_options(const struct pas_meta *meta)
+{
+	if (pas_meta_option(meta->flags,
+			    PAS_META_FLAG_ROOT_REVOKE_ACTIVATE_SHIFT) <=
+	    PAS_META_OPTION_MAX &&
+	    pas_meta_option(meta->flags, PAS_META_FLAG_UIE_KEY_SWITCH_SHIFT) <=
+	    PAS_META_OPTION_MAX &&
+	    pas_meta_option(meta->flags, PAS_META_FLAG_DEBUG_SHIFT) <=
+	    PAS_META_OPTION_MAX)
+		return TEE_SUCCESS;
+
+	EMSG("PAS auth: reserved metadata option value, flags=%#"PRIx32,
+	     meta->flags);
+	return TEE_ERROR_SECURITY;
+}
+
+/*
+ * Device-identity fields consumed by the HW binding checks below, read via
+ * pas_fuse_get_hw_binding_info().
+ */
+struct pas_device_ids {
+	uint32_t oem_id;
+	uint32_t model_id;
+	uint32_t jtag_id;
+	uint32_t serial_num;
+};
+
+/*
+ * Bind OEM_ID and MODEL_ID to the device fuses: each field is checked
+ * unless its *_INDEPENDENT flag exempts it.
+ */
+static TEE_Result check_oem_model_binding(const struct pas_meta *meta,
+					  const struct pas_device_ids *ids)
+{
+	bool oem_independent = meta->flags &
+				BIT32(PAS_META_FLAG_OEM_ID_INDEPENDENT);
+	bool model_independent = false;
+
+	/*
+	 * v0 metadata has no MODEL_ID_INDEPENDENT bit; it is implied by
+	 * OEM_ID_INDEPENDENT.
+	 */
+	if (meta->major == 0)
+		model_independent = oem_independent;
+	else
+		model_independent = meta->flags &
+				    BIT32(PAS_META_FLAG_MODEL_ID_INDEPENDENT);
+
+	if (!oem_independent && meta->oem_id != ids->oem_id) {
+		EMSG("PAS auth: OEM_ID got %#"PRIx32" want %#"PRIx32,
+		     meta->oem_id, ids->oem_id);
+		return TEE_ERROR_SECURITY;
+	}
+
+	if (!model_independent && meta->model_id != ids->model_id) {
+		EMSG("PAS auth: MODEL_ID got %#"PRIx32" want %#"PRIx32,
+		     meta->model_id, ids->model_id);
+		return TEE_ERROR_SECURITY;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Bind HW_ID (JTAG authentication bits) to the device fuse; checked only
+ * when IN_USE_JTAG_ID is set.
+ */
+static TEE_Result check_jtag_binding(const struct pas_meta *meta,
+				     const struct pas_device_ids *ids)
+{
+	if (!(meta->flags & BIT32(PAS_META_FLAG_IN_USE_JTAG_ID)))
+		return TEE_SUCCESS;
+
+	if (meta->hw_id == ids->jtag_id)
+		return TEE_SUCCESS;
+
+	EMSG("PAS auth: HW_ID got %#"PRIx32" want %#"PRIx32, meta->hw_id,
+	     ids->jtag_id);
+	return TEE_ERROR_SECURITY;
+}
+
+/*
+ * Bind the device serial number against the metadata allow-list. Checked when
+ * the metadata's USE_SERIAL_NUMBER flag is set, the APPS SECURE_BOOTn
+ * USE_SERIAL_NUM fuse override forces it, or the DEBUG/root-revoke-activate/
+ * UIE-key-switch option requests its SN-gated enable value. When a trigger
+ * applies, a device with no fused serial is treated as unbindable and the
+ * check fails rather than being skipped.
+ */
+static TEE_Result check_serial_binding(const struct pas_meta *meta,
+				       const struct pas_device_ids *ids,
+				       bool use_serial_num_override)
+{
+	static const uint32_t sn_gated_shifts[] = {
+		PAS_META_FLAG_DEBUG_SHIFT,
+		PAS_META_FLAG_ROOT_REVOKE_ACTIVATE_SHIFT,
+		PAS_META_FLAG_UIE_KEY_SWITCH_SHIFT,
+	};
+	bool sn_gated = false;
+	size_t i = 0;
+
+	for (i = 0; i < ARRAY_SIZE(sn_gated_shifts); i++) {
+		if (pas_meta_option_sn_gated(meta->flags, sn_gated_shifts[i])) {
+			sn_gated = true;
+			break;
+		}
+	}
+
+	if (!(meta->flags & BIT32(PAS_META_FLAG_USE_SERIAL_NUMBER)) &&
+	    !use_serial_num_override && !sn_gated)
+		return TEE_SUCCESS;
+
+	if (!ids->serial_num) {
+		EMSG("PAS auth: serial binding required, no fused serial");
+		return TEE_ERROR_SECURITY;
+	}
+
+	for (i = 0; i < ARRAY_SIZE(meta->serial_num); i++) {
+		if (meta->serial_num[i] &&
+		    meta->serial_num[i] == ids->serial_num)
+			return TEE_SUCCESS;
+	}
+
+	EMSG("PAS auth: serial number %#"PRIx32" not in metadata allow-list",
+	     ids->serial_num);
+	return TEE_ERROR_SECURITY;
+}
+
+/*
+ * Bind the SoC family|device version against the metadata allow-list;
+ * checked only when IN_USE_SOC_HW_VERSION is set.
+ */
+static TEE_Result check_soc_vers_binding(const struct pas_meta *meta,
+					 uint32_t fam_dev)
+{
+	size_t i = 0;
+
+	if (!(meta->flags & BIT32(PAS_META_FLAG_IN_USE_SOC_HW_VERSION)))
+		return TEE_SUCCESS;
+
+	for (i = 0; i < ARRAY_SIZE(meta->soc_vers); i++) {
+		if (meta->soc_vers[i] == fam_dev)
+			return TEE_SUCCESS;
+	}
+
+	EMSG("PAS auth: SOC_HW_VERSION %#"PRIx32" not in metadata allow-list",
+	     fam_dev);
+	return TEE_ERROR_SECURITY;
+}
+
+/*
+ * Bind the signed image to this device's fuses and reject malformed option
+ * fields (HW/OEM/MODEL/serial/SoC binding checks; UIE key-switch handling
+ * excluded, out of scope for PAS peripheral images).
+ */
+static TEE_Result check_hw_binding(const struct pas_mbn *hs)
+{
+	struct pas_fuse_hw_binding_info info = { };
+	struct pas_device_ids ids = { };
+	struct pas_meta meta = { };
+	TEE_Result res = TEE_ERROR_GENERIC;
+	bool need_soc_vers = false;
+
+	res = pas_meta_get(hs, &meta);
+	if (res == TEE_ERROR_NO_DATA)
+		return TEE_SUCCESS; /* No OEM metadata (v5): nothing to bind */
+	if (res) {
+		EMSG("PAS auth: bad OEM metadata in HW binding check");
+		return res;
+	}
+
+	res = check_metadata_options(&meta);
+	if (res)
+		return res;
+
+	need_soc_vers = meta.flags & BIT32(PAS_META_FLAG_IN_USE_SOC_HW_VERSION);
+	res = pas_fuse_get_hw_binding_info(need_soc_vers, &info);
+	if (res)
+		return res;
+
+	ids.oem_id = info.oem_id;
+	ids.model_id = info.model_id;
+	ids.jtag_id = info.jtag_id;
+	ids.serial_num = info.serial_num;
+
+	res = check_oem_model_binding(&meta, &ids);
+	if (res)
+		return res;
+
+	res = check_jtag_binding(&meta, &ids);
+	if (res)
+		return res;
+
+	res = check_serial_binding(&meta, &ids, info.use_serial_num_override);
+	if (res)
+		return res;
+
+	res = check_soc_vers_binding(&meta, info.soc_fam_dev);
+	if (res)
+		return res;
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Reject a UIE-encrypted image. Image decryption is not supported here, so an
+ * encrypted image cannot be authenticated as plaintext. Act only when the
+ * image carries a UIE parameter block AND the OEM_CONFIG0 image-encryption
+ * fuse is provisioned: an image with a UIE block on a device without the fuse
+ * is treated as unencrypted.
+ */
+static TEE_Result reject_if_encrypted(const struct pas_mbn *hs)
+{
+	if (!hs->uie_encrypted)
+		return TEE_SUCCESS;
+
+	if (!pas_fuse_get_image_encryption_en())
+		return TEE_SUCCESS;
+
+	EMSG("PAS auth: UIE image encryption not supported");
+
+	return TEE_ERROR_NOT_SUPPORTED;
+}
+
+/*
+ * Enforce the policy-required signing authority. pas_policy_signer() names the
+ * authority this port supports for @pas_id's SW_ID (currently always
+ * PAS_OEM_SIGNED); any image carrying QTI signing material fails here because
+ * QTI countersignature verification is not implemented. If a future SW_ID
+ * requires PAS_QTI_SIGNED or PAS_DOUBLE_SIGNED, this fails hard too rather
+ * than silently accepting the image on the OEM signature alone.
+ */
+static TEE_Result reject_if_double_signed(const struct pas_mbn *hs,
+					  uint32_t pas_id)
+{
+	enum pas_sign_authority required = PAS_OEM_SIGNED;
+	uint32_t swid = 0;
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = pas_policy_expected_swid(pas_id, &swid);
+	if (res) {
+		EMSG("PAS auth: no SW_ID binding for pas_id %"PRIu32, pas_id);
+		return res;
+	}
+
+	required = pas_policy_signer(swid);
+
+	if (required != PAS_OEM_SIGNED) {
+		EMSG("PAS auth: signer class %d for SW_ID %#"PRIx32
+		     " not implemented", required, swid);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+
+	if (hs->qti_certs || hs->qti_sig) {
+		EMSG("PAS auth: QTI-countersigned images are not supported");
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Validate the certificate chain, bind its root to the device ROT and verify
+ * the signature. Called only when secure boot is enabled; the caller has
+ * already fail-closed on a fuse-PTA read error, so every step here runs
+ * unconditionally.
+ * @anchor is the OEM root-of-trust digest the caller already read from the
+ * fuse PTA (PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE bytes).
+ */
+static TEE_Result verify_authenticity(const struct pas_mbn *hs,
+				      uint32_t pas_id,
+				      const uint8_t *anchor)
+{
+	uint32_t rot_hash_algo = TEE_ALG_SHA384;
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint8_t *signed_copy = NULL;
+	const uint8_t *roots = NULL;
+	uint32_t sig_hash_algo = 0;
+	const uint8_t *leaf = NULL;
+	uint32_t sig_algo = 0;
+	size_t signed_len = 0;
+	size_t roots_len = 0;
+	size_t leaf_len = 0;
+	bool eku_enforced = false;
+
+	if (!hs->oem_certs || !hs->oem_sig || !hs->signed_region) {
+		EMSG("PAS auth: metadata is not OEM-signed");
+		return TEE_ERROR_SECURITY;
+	}
+
+	/*
+	 * Fail closed on a fuse-PTA read failure. A failed EKU enforcement
+	 * fuse read aborts the whole authentication attempt; never fall back
+	 * to "not enforced".
+	 */
+	res = pas_fuse_get_eku_enforcement_en(&eku_enforced);
+	if (res) {
+		EMSG("PAS auth: cannot read EKU enforcement fuse: %#"PRIx32,
+		     res);
+		return res;
+	}
+
+	res = pas_sig_verify_cert_chain(hs->oem_certs, hs->oem_certs_size,
+					eku_enforced, 1, 0, &leaf,
+					&leaf_len, &roots, &roots_len);
+	if (res) {
+		EMSG("PAS auth: OEM cert chain invalid: %#"PRIx32, res);
+		return res;
+	}
+
+	/*
+	 * The root-of-trust digest covers the single provisioned root,
+	 * matching how the anchor fuse is provisioned.
+	 */
+	res = pas_sig_check_root_of_trust(rot_hash_algo,
+					  PTA_QCOM_FUSE_ROOT_OF_TRUST_SIZE,
+					  roots, roots_len, anchor);
+	if (res) {
+		EMSG("PAS auth: root-of-trust mismatch");
+		return res;
+	}
+
+	/* Metadata is authenticated now; bind it to this peripheral. */
+	res = check_metadata_version(hs);
+	if (res)
+		return res;
+
+	res = check_sw_binding(hs, pas_id);
+	if (res)
+		return res;
+
+	res = check_hw_binding(hs);
+	if (res)
+		return res;
+
+	res = pas_sig_algo_from_leaf(leaf, leaf_len, &sig_algo,
+				     &sig_hash_algo);
+	if (res) {
+		EMSG("PAS auth: cannot determine signature algorithm: %#"PRIx32,
+		     res);
+		return res;
+	}
+
+	res = pas_meta_signed_copy(hs, &signed_copy, &signed_len);
+	if (res)
+		return res;
+
+	res = pas_sig_verify_signature(sig_algo, sig_hash_algo, leaf,
+				       leaf_len, signed_copy, signed_len,
+				       hs->oem_sig, hs->oem_sig_size);
+	TEE_Free(signed_copy);
+	if (res) {
+		EMSG("PAS auth: OEM signature verify failed: %#"PRIx32, res);
+		return res;
+	}
+
+	return TEE_SUCCESS;
+}
+
+/*
+ * Determine the per-segment hash digest size for @slot's metadata. The OEM
+ * metadata's root_cert_sel (word 28) selects the fuse-configured algorithm
+ * via the fuse PTA on platforms that implement the field; images without OEM
+ * metadata (MBN v5) or without the fuse field fall back to root_cert_sel 0.
+ */
+#define SECBOOT_DEFAULT_ROOT_CERT_SEL	0U
+
+TEE_Result pas_sig_auth_hash_size(const struct pas_md_slot *slot,
+				  uint32_t *hash_size)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t root_cert_sel = SECBOOT_DEFAULT_ROOT_CERT_SEL;
+	uint32_t version = 0;
+
+	/*
+	 * MBN v5 hash tables are always SHA-256 by format definition; the
+	 * fuse-selected digest applies only to v6. Read the version first and
+	 * short-circuit v5 before consulting the fuse.
+	 */
+	res = pas_meta_peek_version(slot->meta_data, slot->meta_data_size,
+				    &version);
+	if (res)
+		return res;
+	if (version == PAS_MBN_VERSION_5) {
+		*hash_size = TEE_SHA256_HASH_SIZE;
+		return TEE_SUCCESS;
+	}
+
+	res = pas_meta_peek_root_cert_sel(slot->meta_data,
+					  slot->meta_data_size,
+					  &root_cert_sel);
+	if (res == TEE_ERROR_NO_DATA)
+		root_cert_sel = SECBOOT_DEFAULT_ROOT_CERT_SEL;
+	else if (res)
+		return res;
+
+	res = pas_fuse_get_segment_hash_size(root_cert_sel, hash_size);
+	if (res) {
+		/*
+		 * Fuse-PTA read failed. A silent SHA-384 fallback would
+		 * mis-hash a v6 image whose fuse-selected algorithm differs.
+		 * Fail hard rather than defaulting to any digest.
+		 */
+		EMSG("PAS auth: segment hash size read failed: %#"PRIx32, res);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result pas_sig_auth_authenticate(const struct pas_mbn *hs,
+				     const uint8_t *meta_data,
+				     size_t meta_data_size,
+				     uint32_t pas_id, uint32_t hash_size,
+				     const uint8_t *anchor)
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	res = reject_if_encrypted(hs);
+	if (res)
+		return res;
+
+	res = reject_if_double_signed(hs, pas_id);
+	if (res)
+		return res;
+
+	res = verify_authenticity(hs, pas_id, anchor);
+	if (res)
+		return res;
+
+	res = pas_meta_verify_preamble(meta_data, meta_data_size,
+				       hs->hash_table, hash_size);
+	if (res)
+		return res;
+
+	return TEE_SUCCESS;
+}

--- a/ta/qcom_pas/src/pas_sig_auth.c
+++ b/ta/qcom_pas/src/pas_sig_auth.c
@@ -23,11 +23,16 @@
 #include <util.h>
 
 /*
- * Accepted metadata major versions: V0 (0) and V1 (1); minor must be 0.
+ * Accepted metadata major versions: V0 (0) and V1 (1) for MBN v6, minor must
+ * be 0. MBN v7 uses a disjoint major-version scheme (2.0/3.0, selecting the
+ * soc_feature_id/product_segment_id union member) checked separately below.
  */
 #define SECBOOT_METADATA_MAJOR_V0	0U
 #define SECBOOT_METADATA_MAJOR_V1	1U
 #define SECBOOT_METADATA_MINOR		0U
+
+#define SECBOOT_METADATA7_MAJOR_V2	2U
+#define SECBOOT_METADATA7_MAJOR_V3	3U
 
 /*
  * Reject metadata whose major/minor version falls outside the accepted set.
@@ -37,6 +42,7 @@ static TEE_Result check_metadata_version(const struct pas_mbn *hs)
 {
 	TEE_Result res = TEE_ERROR_GENERIC;
 	struct pas_meta meta = { };
+	bool valid = false;
 
 	res = pas_meta_get(hs, &meta);
 	if (res == TEE_ERROR_NO_DATA)
@@ -46,9 +52,15 @@ static TEE_Result check_metadata_version(const struct pas_mbn *hs)
 		return res;
 	}
 
-	if ((meta.major == SECBOOT_METADATA_MAJOR_V0 ||
-	     meta.major == SECBOOT_METADATA_MAJOR_V1) &&
-	    meta.minor == SECBOOT_METADATA_MINOR)
+	if (hs->version == PAS_MBN_VERSION_7)
+		valid = (meta.major == SECBOOT_METADATA7_MAJOR_V2 ||
+			meta.major == SECBOOT_METADATA7_MAJOR_V3) &&
+			meta.minor == SECBOOT_METADATA_MINOR;
+	else
+		valid = (meta.major == SECBOOT_METADATA_MAJOR_V0 ||
+			meta.major == SECBOOT_METADATA_MAJOR_V1) &&
+			meta.minor == SECBOOT_METADATA_MINOR;
+	if (valid)
 		return TEE_SUCCESS;
 
 	EMSG("PAS auth: unsupported metadata version %"PRIu32".%"PRIu32,
@@ -143,19 +155,44 @@ struct pas_device_ids {
 };
 
 /*
- * Bind OEM_ID and MODEL_ID to the device fuses: each field is checked
- * unless its *_INDEPENDENT flag exempts it.
+ * True if @meta's SoC-HW-version binding is active: v6's IN_USE_SOC_HW_VERSION
+ * flag, or v7's SOC_HW_VERSION_BOUND flag pair being "10" (bound).
+ */
+static bool pas_meta_soc_vers_bound(const struct pas_meta *meta)
+{
+	if (meta->is_v7)
+		return pas_meta7_flag_bound(meta->flags,
+			PAS_META7_FLAG_SOC_HW_VERSION_BOUND_SHIFT);
+	return meta->flags & BIT32(PAS_META_FLAG_IN_USE_SOC_HW_VERSION);
+}
+
+/*
+ * True if @meta's JTAG-ID binding is active: v6's IN_USE_JTAG_ID flag, or
+ * v7's JTAG_ID_BOUND flag pair being "10" (bound).
+ */
+static bool pas_meta_jtag_bound(const struct pas_meta *meta)
+{
+	if (meta->is_v7)
+		return pas_meta7_flag_bound(meta->flags,
+					    PAS_META7_FLAG_JTAG_ID_BOUND_SHIFT);
+	return meta->flags & BIT32(PAS_META_FLAG_IN_USE_JTAG_ID);
+}
+
+/*
+ * Bind OEM_ID and MODEL_ID to the device fuses. v6: each field is checked
+ * unless its *_INDEPENDENT flag exempts it. v7: each field is checked only
+ * when its *_BOUND flag pair is "10" (bound).
  */
 static TEE_Result check_oem_model_binding(const struct pas_meta *meta,
 					  const struct pas_device_ids *ids)
 {
-	bool oem_independent = meta->flags &
-				BIT32(PAS_META_FLAG_OEM_ID_INDEPENDENT);
+	bool oem_independent = false;
 	bool model_independent = false;
 
 	/*
 	 * v0 metadata has no MODEL_ID_INDEPENDENT bit; it is implied by
-	 * OEM_ID_INDEPENDENT.
+	 * OEM_ID_INDEPENDENT. Reading bit 11 unconditionally wrongly
+	 * enforced MODEL_ID binding on v0-signed images.
 	 */
 	if (meta->major == 0)
 		model_independent = oem_independent;
@@ -179,13 +216,14 @@ static TEE_Result check_oem_model_binding(const struct pas_meta *meta,
 }
 
 /*
- * Bind HW_ID (JTAG authentication bits) to the device fuse; checked only
- * when IN_USE_JTAG_ID is set.
+ * Bind HW_ID (JTAG authentication bits) to the device fuse. v6: checked only
+ * when IN_USE_JTAG_ID is set. v7: checked only when the JTAG_ID_BOUND flag
+ * pair is "10" (bound).
  */
 static TEE_Result check_jtag_binding(const struct pas_meta *meta,
 				     const struct pas_device_ids *ids)
 {
-	if (!(meta->flags & BIT32(PAS_META_FLAG_IN_USE_JTAG_ID)))
+	if (!pas_meta_jtag_bound(meta))
 		return TEE_SUCCESS;
 
 	if (meta->hw_id == ids->jtag_id)
@@ -200,9 +238,13 @@ static TEE_Result check_jtag_binding(const struct pas_meta *meta,
  * Bind the device serial number against the metadata allow-list. Checked when
  * the metadata's USE_SERIAL_NUMBER flag is set, the APPS SECURE_BOOTn
  * USE_SERIAL_NUM fuse override forces it, or the DEBUG/root-revoke-activate/
- * UIE-key-switch option requests its SN-gated enable value. When a trigger
- * applies, a device with no fused serial is treated as unbindable and the
- * check fails rather than being skipped.
+ * UIE-key-switch option requests its SN-gated enable value (the reference
+ * gates each of those three on a serial match, independently of whether this
+ * TA acts on the requested permission). When none of those triggers apply,
+ * the check is skipped entirely, matching the reference. When a trigger does
+ * apply, the reference treats a device with no fused serial as unbindable
+ * and fails the check rather than skipping it - a zero fused serial is not a
+ * no-op here either.
  */
 static TEE_Result check_serial_binding(const struct pas_meta *meta,
 				       const struct pas_device_ids *ids,
@@ -213,18 +255,25 @@ static TEE_Result check_serial_binding(const struct pas_meta *meta,
 		PAS_META_FLAG_ROOT_REVOKE_ACTIVATE_SHIFT,
 		PAS_META_FLAG_UIE_KEY_SWITCH_SHIFT,
 	};
+	uint32_t v7_shift = PAS_META7_FLAG_SERIAL_NUMBER_BOUND_SHIFT;
+	bool bound = false;
 	bool sn_gated = false;
 	size_t i = 0;
 
-	for (i = 0; i < ARRAY_SIZE(sn_gated_shifts); i++) {
-		if (pas_meta_option_sn_gated(meta->flags, sn_gated_shifts[i])) {
-			sn_gated = true;
-			break;
+	if (meta->is_v7) {
+		bound = pas_meta7_flag_bound(meta->flags, v7_shift);
+	} else {
+		bound = meta->flags & BIT32(PAS_META_FLAG_USE_SERIAL_NUMBER);
+		for (i = 0; i < ARRAY_SIZE(sn_gated_shifts); i++) {
+			if (pas_meta_option_sn_gated(meta->flags,
+						     sn_gated_shifts[i])) {
+				sn_gated = true;
+				break;
+			}
 		}
 	}
 
-	if (!(meta->flags & BIT32(PAS_META_FLAG_USE_SERIAL_NUMBER)) &&
-	    !use_serial_num_override && !sn_gated)
+	if (!bound && !use_serial_num_override && !sn_gated)
 		return TEE_SUCCESS;
 
 	if (!ids->serial_num) {
@@ -245,14 +294,15 @@ static TEE_Result check_serial_binding(const struct pas_meta *meta,
 
 /*
  * Bind the SoC family|device version against the metadata allow-list;
- * checked only when IN_USE_SOC_HW_VERSION is set.
+ * checked only when the SoC-HW-version binding is active (see
+ * pas_meta_soc_vers_bound()).
  */
 static TEE_Result check_soc_vers_binding(const struct pas_meta *meta,
 					 uint32_t fam_dev)
 {
 	size_t i = 0;
 
-	if (!(meta->flags & BIT32(PAS_META_FLAG_IN_USE_SOC_HW_VERSION)))
+	if (!pas_meta_soc_vers_bound(meta))
 		return TEE_SUCCESS;
 
 	for (i = 0; i < ARRAY_SIZE(meta->soc_vers); i++) {
@@ -263,6 +313,31 @@ static TEE_Result check_soc_vers_binding(const struct pas_meta *meta,
 	EMSG("PAS auth: SOC_HW_VERSION %#"PRIx32" not in metadata allow-list",
 	     fam_dev);
 	return TEE_ERROR_SECURITY;
+}
+
+/*
+ * Reject a v7 image that binds to neither JTAG_ID nor SOC_HW_VERSION unless
+ * its SW_ID is present in the hardware-independent SW-ID allow list. Mirrors
+ * the reference: TZ_APP images may run unbound to either hardware
+ * identifier; every other SW_ID must bind to at least one.
+ */
+#define SECBOOT_TZ_APP_SW_TYPE	0x0CU
+
+static TEE_Result check_jtag_or_soc_vers_binding(const struct pas_meta *meta,
+						 bool secboot_on)
+{
+	if (pas_meta_jtag_bound(meta) || pas_meta_soc_vers_bound(meta))
+		return TEE_SUCCESS;
+
+	if (meta->sw_id == SECBOOT_TZ_APP_SW_TYPE)
+		return TEE_SUCCESS;
+
+	EMSG("PAS auth: SW_ID %#"PRIx32" unbound to JTAG_ID and SOC_VERS",
+	     meta->sw_id);
+	if (secboot_on)
+		return TEE_ERROR_SECURITY;
+	IMSG("PAS auth: JTAG/SOC_VERS binding failure tolerated");
+	return TEE_SUCCESS;
 }
 
 /*
@@ -286,11 +361,11 @@ static TEE_Result check_hw_binding(const struct pas_mbn *hs)
 		return res;
 	}
 
-	res = check_metadata_options(&meta);
+	res = check_metadata_options(&meta, secboot_on);
 	if (res)
 		return res;
 
-	need_soc_vers = meta.flags & BIT32(PAS_META_FLAG_IN_USE_SOC_HW_VERSION);
+	need_soc_vers = pas_meta_soc_vers_bound(&meta);
 	res = pas_fuse_get_hw_binding_info(need_soc_vers, &info);
 	if (res)
 		return res;
@@ -315,6 +390,9 @@ static TEE_Result check_hw_binding(const struct pas_mbn *hs)
 	res = check_soc_vers_binding(&meta, info.soc_fam_dev);
 	if (res)
 		return res;
+
+	DMSG("PAS auth: HW binding ok (oem=%#"PRIx32" model=%#"PRIx32")",
+	     ids.oem_id, ids.model_id);
 
 	return TEE_SUCCESS;
 }
@@ -458,7 +536,7 @@ static TEE_Result verify_authenticity(const struct pas_mbn *hs,
 		return res;
 	}
 
-	res = pas_meta_signed_copy(hs, &signed_copy, &signed_len);
+	res = pas_meta_oem_signed_copy(hs, &signed_copy, &signed_len);
 	if (res)
 		return res;
 
@@ -475,10 +553,12 @@ static TEE_Result verify_authenticity(const struct pas_mbn *hs,
 }
 
 /*
- * Determine the per-segment hash digest size for @slot's metadata. The OEM
- * metadata's root_cert_sel (word 28) selects the fuse-configured algorithm
- * via the fuse PTA on platforms that implement the field; images without OEM
- * metadata (MBN v5) or without the fuse field fall back to root_cert_sel 0.
+ * Determine the per-segment hash digest size for @slot's metadata, mirroring
+ * the reference segment-hash-algorithm selection: the OEM metadata's
+ * root_cert_sel (word 28) selects the fuse-configured algorithm via the fuse
+ * PTA on platforms that implement the field; images without OEM metadata
+ * (MBN v5) or without the fuse field use the reference default
+ * root_cert_sel of 0.
  */
 #define SECBOOT_DEFAULT_ROOT_CERT_SEL	0U
 
@@ -502,6 +582,9 @@ TEE_Result pas_sig_auth_hash_size(const struct pas_md_slot *slot,
 		*hash_size = TEE_SHA256_HASH_SIZE;
 		return TEE_SUCCESS;
 	}
+	if (version == PAS_MBN_VERSION_7)
+		return pas_meta_peek_hash_table_algo(slot->md, slot->md_size,
+						     hash_size);
 
 	res = pas_meta_peek_root_cert_sel(slot->meta_data,
 					  slot->meta_data_size,

--- a/ta/qcom_pas/src/pas_sig_auth.c
+++ b/ta/qcom_pas/src/pas_sig_auth.c
@@ -295,7 +295,8 @@ static TEE_Result check_serial_binding(const struct pas_meta *meta,
 /*
  * Bind the SoC family|device version against the metadata allow-list;
  * checked only when the SoC-HW-version binding is active (see
- * pas_meta_soc_vers_bound()).
+ * pas_meta_soc_vers_bound()). v7 additionally rejects a zero fused family
+ * number outright when the binding is active - v6 has no such guard.
  */
 static TEE_Result check_soc_vers_binding(const struct pas_meta *meta,
 					 uint32_t fam_dev)
@@ -304,6 +305,14 @@ static TEE_Result check_soc_vers_binding(const struct pas_meta *meta,
 
 	if (!pas_meta_soc_vers_bound(meta))
 		return TEE_SUCCESS;
+
+	if (meta->is_v7 && !fam_dev) {
+		EMSG("PAS auth: SOC_HW_VERSION family number is zero");
+		if (secboot_on)
+			return TEE_ERROR_SECURITY;
+		IMSG("PAS auth: zero SOC_HW_VERSION tolerated");
+		return TEE_SUCCESS;
+	}
 
 	for (i = 0; i < ARRAY_SIZE(meta->soc_vers); i++) {
 		if (meta->soc_vers[i] == fam_dev)

--- a/ta/qcom_pas/src/pas_sig_auth.c
+++ b/ta/qcom_pas/src/pas_sig_auth.c
@@ -308,10 +308,7 @@ static TEE_Result check_soc_vers_binding(const struct pas_meta *meta,
 
 	if (meta->is_v7 && !fam_dev) {
 		EMSG("PAS auth: SOC_HW_VERSION family number is zero");
-		if (secboot_on)
-			return TEE_ERROR_SECURITY;
-		IMSG("PAS auth: zero SOC_HW_VERSION tolerated");
-		return TEE_SUCCESS;
+		return TEE_ERROR_SECURITY;
 	}
 
 	for (i = 0; i < ARRAY_SIZE(meta->soc_vers); i++) {
@@ -332,8 +329,7 @@ static TEE_Result check_soc_vers_binding(const struct pas_meta *meta,
  */
 #define SECBOOT_TZ_APP_SW_TYPE	0x0CU
 
-static TEE_Result check_jtag_or_soc_vers_binding(const struct pas_meta *meta,
-						 bool secboot_on)
+static TEE_Result check_jtag_or_soc_vers_binding(const struct pas_meta *meta)
 {
 	if (pas_meta_jtag_bound(meta) || pas_meta_soc_vers_bound(meta))
 		return TEE_SUCCESS;
@@ -343,10 +339,7 @@ static TEE_Result check_jtag_or_soc_vers_binding(const struct pas_meta *meta,
 
 	EMSG("PAS auth: SW_ID %#"PRIx32" unbound to JTAG_ID and SOC_VERS",
 	     meta->sw_id);
-	if (secboot_on)
-		return TEE_ERROR_SECURITY;
-	IMSG("PAS auth: JTAG/SOC_VERS binding failure tolerated");
-	return TEE_SUCCESS;
+	return TEE_ERROR_SECURITY;
 }
 
 /*
@@ -370,7 +363,7 @@ static TEE_Result check_hw_binding(const struct pas_mbn *hs)
 		return res;
 	}
 
-	res = check_metadata_options(&meta, secboot_on);
+	res = check_metadata_options(&meta);
 	if (res)
 		return res;
 
@@ -592,7 +585,7 @@ TEE_Result pas_sig_auth_hash_size(const struct pas_md_slot *slot,
 		return TEE_SUCCESS;
 	}
 	if (version == PAS_MBN_VERSION_7)
-		return pas_meta_peek_hash_table_algo(slot->md, slot->md_size,
+		return pas_meta_peek_hash_table_algo(slot->meta_data, slot->meta_data_size,
 						     hash_size);
 
 	res = pas_meta_peek_root_cert_sel(slot->meta_data,

--- a/ta/qcom_pas/src/qcom_pas.c
+++ b/ta/qcom_pas/src/qcom_pas.c
@@ -4,6 +4,7 @@
  */
 
 #include <pas_auth.h>
+#include <pas_fuse.h>
 #include <pta_qcom_pas.h>
 #include <qcom_pas_priv.h>
 #include <ta_qcom_pas.h>
@@ -111,6 +112,12 @@ TEE_Result TA_OpenSessionEntryPoint(uint32_t pt,
 					&pta_session, NULL);
 		if (res != TEE_SUCCESS)
 			goto error_free;
+
+		res = pas_fuse_open();
+		if (res != TEE_SUCCESS) {
+			TEE_CloseTASession(pta_session);
+			goto error_free;
+		}
 	}
 
 	session_refcount++;
@@ -143,8 +150,10 @@ void TA_CloseSessionEntryPoint(void *sess_ctx)
 
 	session_refcount--;
 
-	if (!session_refcount)
+	if (!session_refcount) {
+		pas_fuse_close();
 		TEE_CloseTASession(pta_session);
+	}
 }
 
 TEE_Result TA_InvokeCommandEntryPoint(void *sess_ctx, uint32_t cmd_id,

--- a/ta/qcom_pas/src/qcom_pas.c
+++ b/ta/qcom_pas/src/qcom_pas.c
@@ -1,29 +1,65 @@
 // SPDX-License-Identifier: BSD-2-Clause
 /*
- * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ * Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
  */
 
+#include <pas_auth.h>
 #include <pta_qcom_pas.h>
+#include <qcom_pas_priv.h>
 #include <ta_qcom_pas.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>
 #include <types_ext.h>
 #include <utee_defines.h>
 
+/*
+ * The PTA session wraps the core-side PAS driver and does not carry
+ * per-image state; it is shared across all TA sessions. refcount tracks
+ * when to open and close it.
+ */
 static size_t session_refcount;
 static TEE_TASessionHandle pta_session;
 
-static TEE_Result qcom_pas_auth_and_reset(uint32_t pt,
+static TEE_Result qcom_pas_init_image(struct qcom_pas_session *s, uint32_t pt,
+				      TEE_Param params[TEE_NUM_PARAMS])
+{
+	TEE_Result res = TEE_ERROR_GENERIC;
+
+	/*
+	 * Invoke the PTA first, then stash the metadata into a session slot
+	 * only on success. Doing this the other way round leaks a slot on
+	 * every failed PTA invocation - repeated failures across distinct
+	 * pas_id values would eventually exhaust PAS_MD_SLOTS and leak the
+	 * associated TA heap until the session is torn down.
+	 */
+	res = TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
+				  PTA_QCOM_PAS_INIT_IMAGE, pt, params, NULL);
+	if (res)
+		return res;
+
+	res = pas_auth_save_metadata(s, pt, params);
+	if (res)
+		return res;
+
+	return pas_auth_authenticate(s, params[0].value.a);
+}
+
+static TEE_Result qcom_pas_auth_and_reset(struct qcom_pas_session *s,
+					  uint32_t pt,
 					  TEE_Param params[TEE_NUM_PARAMS])
 {
 	const uint32_t exp_pt = TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
 						TEE_PARAM_TYPE_VALUE_INPUT,
 						TEE_PARAM_TYPE_MEMREF_INPUT,
 						TEE_PARAM_TYPE_NONE);
+	TEE_Result res = TEE_ERROR_GENERIC;
+
 	if (pt != exp_pt)
 		return TEE_ERROR_BAD_PARAMETERS;
 
-	/* Firmware authentication - TODO */
+	res = pas_auth_verify_reset(s, pta_session, params[0].value.a, params);
+	if (res)
+		return res;
 
 	return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
 				   PTA_QCOM_PAS_AUTH_AND_RESET,
@@ -41,11 +77,12 @@ void TA_DestroyEntryPoint(void)
 
 TEE_Result TA_OpenSessionEntryPoint(uint32_t pt,
 				    TEE_Param params[TEE_NUM_PARAMS],
-				    void **sess __unused)
+				    void **sess_ctx)
 {
 	static const TEE_UUID uuid = PTA_QCOM_PAS_UUID;
-	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_PropSetHandle h = TEE_HANDLE_NULL;
+	struct qcom_pas_session *s = NULL;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	TEE_Identity id = { };
 
 	res = TEE_AllocatePropertyEnumerator(&h);
@@ -63,34 +100,59 @@ TEE_Result TA_OpenSessionEntryPoint(uint32_t pt,
 		goto error;
 	}
 
+	s = TEE_Malloc(sizeof(*s), TEE_MALLOC_FILL_ZERO);
+	if (!s) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto error;
+	}
+
 	if (!session_refcount) {
 		res = TEE_OpenTASession(&uuid, TEE_TIMEOUT_INFINITE, pt, params,
 					&pta_session, NULL);
 		if (res != TEE_SUCCESS)
-			goto error;
+			goto error_free;
 	}
 
 	session_refcount++;
+	*sess_ctx = s;
 	res = TEE_SUCCESS;
+	goto out;
+
+error_free:
+	TEE_Free(s);
 error:
+	*sess_ctx = NULL;
+out:
 	if (h)
 		TEE_FreePropertyEnumerator(h);
 
 	return res;
 }
 
-void TA_CloseSessionEntryPoint(void *sess __unused)
+void TA_CloseSessionEntryPoint(void *sess_ctx)
 {
+	struct qcom_pas_session *s = sess_ctx;
+
+	if (s) {
+		size_t i = 0;
+
+		for (i = 0; i < PAS_MD_SLOTS; i++)
+			TEE_Free(s->slots[i].meta_data);
+		TEE_Free(s);
+	}
+
 	session_refcount--;
 
 	if (!session_refcount)
 		TEE_CloseTASession(pta_session);
 }
 
-TEE_Result TA_InvokeCommandEntryPoint(void *sess __unused, uint32_t cmd_id,
+TEE_Result TA_InvokeCommandEntryPoint(void *sess_ctx, uint32_t cmd_id,
 				      uint32_t pt,
 				      TEE_Param params[TEE_NUM_PARAMS])
 {
+	struct qcom_pas_session *s = sess_ctx;
+
 	switch (cmd_id) {
 	case TA_QCOM_PAS_IS_SUPPORTED:
 		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
@@ -101,9 +163,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *sess __unused, uint32_t cmd_id,
 					   PTA_QCOM_PAS_CAPABILITIES,
 					   pt, params, NULL);
 	case TA_QCOM_PAS_INIT_IMAGE:
-		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
-					   PTA_QCOM_PAS_INIT_IMAGE,
-					   pt, params, NULL);
+		return qcom_pas_init_image(s, pt, params);
 	case TA_QCOM_PAS_MEM_SETUP:
 		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
 					   PTA_QCOM_PAS_MEM_SETUP,
@@ -113,7 +173,7 @@ TEE_Result TA_InvokeCommandEntryPoint(void *sess __unused, uint32_t cmd_id,
 					   PTA_QCOM_PAS_GET_RESOURCE_TABLE,
 					   pt, params, NULL);
 	case TA_QCOM_PAS_AUTH_AND_RESET:
-		return qcom_pas_auth_and_reset(pt, params);
+		return qcom_pas_auth_and_reset(s, pt, params);
 	case TA_QCOM_PAS_SET_REMOTE_STATE:
 		return TEE_InvokeTACommand(pta_session, TEE_TIMEOUT_INFINITE,
 					   PTA_QCOM_PAS_SET_REMOTE_STATE,

--- a/ta/qcom_pas/src/sub.mk
+++ b/ta/qcom_pas/src/sub.mk
@@ -1,1 +1,3 @@
+global-incdirs-y += ../include
 srcs-y += qcom_pas.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_mbn_parser.c

--- a/ta/qcom_pas/src/sub.mk
+++ b/ta/qcom_pas/src/sub.mk
@@ -1,3 +1,3 @@
 global-incdirs-y += ../include
 srcs-y += qcom_pas.c
-srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth.c pas_mbn_parser.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth.c pas_mbn_parser.c pas_meta.c

--- a/ta/qcom_pas/src/sub.mk
+++ b/ta/qcom_pas/src/sub.mk
@@ -1,3 +1,3 @@
 global-incdirs-y += ../include
 srcs-y += qcom_pas.c
-srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth.c pas_fuse.c pas_mbn_parser.c pas_meta.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth.c pas_fuse.c pas_mbn_parser.c pas_meta.c pas_policy.c pas_sig.c pas_sig_auth.c

--- a/ta/qcom_pas/src/sub.mk
+++ b/ta/qcom_pas/src/sub.mk
@@ -1,3 +1,3 @@
 global-incdirs-y += ../include
 srcs-y += qcom_pas.c
-srcs-$(CFG_QCOM_PAS_AUTH) += pas_mbn_parser.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth.c pas_mbn_parser.c

--- a/ta/qcom_pas/src/sub.mk
+++ b/ta/qcom_pas/src/sub.mk
@@ -1,3 +1,3 @@
 global-incdirs-y += ../include
 srcs-y += qcom_pas.c
-srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth.c pas_mbn_parser.c pas_meta.c
+srcs-$(CFG_QCOM_PAS_AUTH) += pas_auth.c pas_fuse.c pas_mbn_parser.c pas_meta.c

--- a/ta/qcom_pas/src/user_ta_header_defines.h
+++ b/ta/qcom_pas/src/user_ta_header_defines.h
@@ -14,16 +14,20 @@
 					 TA_FLAG_SINGLE_INSTANCE | \
 					 TA_FLAG_INSTANCE_KEEP_ALIVE)
 
-/* Provisioned stack size */
+/*
+ * Provisioned stack size. mbedtls X.509/ECDSA verification recurses
+ * deeply and needs more than the hash-only default.
+ */
+#ifdef CFG_QCOM_PAS_AUTH
+#define TA_STACK_SIZE			(32 * 1024)
+#else
 #define TA_STACK_SIZE			(4 * 1024)
+#endif
 
-/* Provisioned heap size for TEE_Malloc() and friends */
 #define TA_DATA_SIZE			CFG_PAS_TA_HEAP_SIZE
 
-/* The gpd.ta.version property */
 #define TA_VERSION	"1.0"
 
-/* The gpd.ta.description property */
 #define TA_DESCRIPTION	"remote processor firmware management"
 
 #endif /* USER_TA_HEADER_DEFINES_H */

--- a/ta/qcom_pas/user_ta.mk
+++ b/ta/qcom_pas/user_ta.mk
@@ -4,12 +4,16 @@ user-ta-uuid := cff7d191-7ca0-4784-af13-48223b9a4fbe
 # ~400 KB. Size the heap to hold a full TEE-private copy when
 # CFG_QCOM_PAS_AUTH is enabled.
 ifeq ($(CFG_QCOM_PAS_AUTH),y)
-CFG_PAS_TA_HEAP_SIZE ?= (512 * 1024)
+# X.509 cert-chain parsing and ECDSA/ECP verification need working
+# memory beyond the metadata copy; give it headroom.
+CFG_PAS_TA_HEAP_SIZE ?= (1024 * 1024)
 else
 CFG_PAS_TA_HEAP_SIZE ?= (4 * 1024)
 endif
 
-# Verify each PIL firmware image before releasing the peripheral from
-# reset: re-hash the loaded segments and compare them against the
-# per-segment hash table carried in the image metadata.
+# Authenticate each PIL firmware image: at INIT_IMAGE validate the
+# certificate chain, signature and fuse bindings (secure-boot devices),
+# then at AUTH_AND_RESET re-hash the loaded segments against the
+# authenticated per-segment hash table before releasing the peripheral
+# from reset.
 CFG_QCOM_PAS_AUTH ?= n

--- a/ta/qcom_pas/user_ta.mk
+++ b/ta/qcom_pas/user_ta.mk
@@ -1,4 +1,15 @@
 user-ta-uuid := cff7d191-7ca0-4784-af13-48223b9a4fbe
 
-# PAS TA heap size can be customized if 4kB is not enough
+# INIT_IMAGE metadata (ELF hdr + phdr table + hash segment) is up to
+# ~400 KB. Size the heap to hold a full TEE-private copy when
+# CFG_QCOM_PAS_AUTH is enabled.
+ifeq ($(CFG_QCOM_PAS_AUTH),y)
+CFG_PAS_TA_HEAP_SIZE ?= (512 * 1024)
+else
 CFG_PAS_TA_HEAP_SIZE ?= (4 * 1024)
+endif
+
+# Verify each PIL firmware image before releasing the peripheral from
+# reset: re-hash the loaded segments and compare them against the
+# per-segment hash table carried in the image metadata.
+CFG_QCOM_PAS_AUTH ?= n


### PR DESCRIPTION
## Summary

This series enables PIL (Peripheral Image Loading) firmware authentication for the Qualcomm Wildcat/Nord (SA8797P) platform in OP-TEE. It extends the existing Hoya PIL authentication framework to support Nord's hardware and MBN v7 metadata format.

**Depends on:** [PR#20](https://github.com/qualcomm-linux/optee_os/pull/20)

## Key Changes

### MBN v7 Metadata Support
- Parse and validate MBN v7 common-metadata and per-signing-metadata blocks
- Implement v7-specific binding checks: lifecycle state, OEM root-cert-hash, SOC feature/segment ID
- Support v7's 2-bit flag encoding (distinct from v6's single-bit encoding)
- Validate hash-table algorithm selection from signed common-metadata (no fuse lookup needed for v7)

### Nord Platform Enablement
- Add Nord QFPROM register definitions (`core/drivers/qcom/qfprom/nord/qfprom_target.h`)
- Enable `CFG_QCOM_PAS_AUTH` for Nord using sense registers instead of QFPROM driver
- Gate anti-rollback (ARB) code for Nord (requires QFPROM corrected/raw registers not available on Nord)
- Refactor fuse reads to use `phys_to_virt()` directly, removing QFPROM driver context dependency
        - Nord sense-register fuse reads validated against hardware specification

### Security Fixes
- Reject zero SOC_HW_VERSION family number when SOC_HW_VERSION binding is active (v7-only)
- Validate common-metadata major/minor version before accepting hash_table_algo
- Fix v6/v7 flag encoding mismatch in OEM_ID/MODEL_ID binding checks

## Commits

12. **ta: qcom_pas: parse MBN version 7 hash segments** — MBN v7 parsing
13. **ta: qcom_pas: bind MBN version 7 metadata to device fuses** — MBN v7 binding checks
14. **ta: qcom_pas: close two MBN v7 validation gaps** — v7 security fixes
15. **chore: use phys_to_virt() directly in secboot read helpers** — Refactor fuse reads for Nord
16. **drivers: qcom: qfprom: add nord fuse register definitions** — Nord QFPROM registers
17. **plat-qcom: wildcat: nord: enable PAS firmware loading and authentication** — Nord platform enablement




