### PR TITLE
drivers: qcom: rpmh: fix MSGID length field encoding

### DIFF
--- a/core/drivers/qcom/rpmh/rpmh_hal.c
+++ b/core/drivers/qcom/rpmh/rpmh_hal.c
@@ -230,9 +230,9 @@ enum hal_status hal_rpmh_write_cmd(enum rsc_drv_id drv_id,
 	cmd_base = tcs_base + TCS_CMD_BASE_OFFSET + (cmd_idx * TCS_CMD_STRIDE);
 
 	msgid = 0;
-	msgid |= SHIFT_U32(0, MSGID_READ_OR_WRITE_SHIFT);
+	msgid |= SHIFT_U32(MSGID_WRITE, MSGID_READ_OR_WRITE_SHIFT);
 	msgid |= SHIFT_U32((completion ? 1 : 0), MSGID_RES_REQ_SHIFT);
-	msgid |= SHIFT_U32(1, MSGID_MSG_LENGTH_SHIFT);
+	msgid |= SHIFT_U32(MSGID_MSG_LENGTH_VALUE, MSGID_MSG_LENGTH_SHIFT);
 
 	slave_id = (addr >> 16) & 0x7;
 	offset = addr & 0xFFFF;

--- a/core/drivers/qcom/rpmh/rpmh_hal.h
+++ b/core/drivers/qcom/rpmh/rpmh_hal.h
@@ -53,6 +53,12 @@ enum hal_status {
 #define MSGID_RES_REQ_SHIFT		0x8
 #define MSGID_MSG_LENGTH_SHIFT		0x0
 
+#define MSGID_READ			0x0
+#define MSGID_WRITE			0x1
+
+/* Each RPMh command transfers a single 32-bit word (encoded as 8 bytes). */
+#define MSGID_MSG_LENGTH_VALUE		0x8
+
 #define ADDR_SLV_ID_SHIFT		0x10
 #define ADDR_OFFSET_SHIFT		0x0
 


### PR DESCRIPTION
The RPMh command MSGID encodes a MSG_LENGTH field describing the
payload length, in bytes, of the command. This field was hardcoded
to 1 which is leading to unpredictable behavior on the
AOP side (including the command never being acknowledged, causing timeouts).

Changing it to 8 (the correct length for the single 32-bit data
word every RPMh command carries), introducing macros MSGID_MSG_LENGTH_VALUE,
MSGID_WRITE, MSGID_READ so the expected encoding is explicit.

Using MSGID_WRITE since it's a write command.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
