### PR TITLE
pta: qcom: pas: nord: register HPASS0-2 and NSPSS0-3 PAS subsystems

### DIFF
--- a/core/pta/qcom/pas/platform/nord/hpass0.c
+++ b/core/pta/qcom/pas/platform/nord/hpass0.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <io.h>
+#include <platform_config.h>
+#include <resource_table.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "hpass0.h"
+
+/*
+ * QDSP6 boot registers for each HPS instance. The PUB block
+ * holds the reset/boot FSM registers; the TCSR block holds the EVB select. 
+ */
+#define HPASS_BASE_OFFSET				(0xC00000)
+#define HPASS_TCSR_REGS_REG_OFFSET		(0x1580000)
+
+#define HPASS_QDSP6SS_RST_EVB			(0x10)
+
+#define HPASS_TCSR_EVB_SEL_OFFSET		(0x3000)
+#define HPASS_TCSR_EVB_SEL_STRIDE		(0x1000)
+#define HPASS_INSTANCE_IDX				(0x0)
+
+#define HPASS_EFUSE_Q6SS_EVB_SEL		(HPASS_TCSR_REGS_REG_OFFSET - HPASS_BASE_OFFSET + \
+						 HPASS_TCSR_EVB_SEL_OFFSET + \
+						 (HPASS_TCSR_EVB_SEL_STRIDE * HPASS_INSTANCE_IDX))
+
+#define BOOT_FSM_TIMEOUT				(10000)
+
+static const struct fw_rsc_devmem hpass_mem_res[] = { };
+
+DEFINE_RESOURCE_TABLE(HPASS, ARRAY_SIZE(hpass_mem_res));
+
+static TEE_Result hpass_fw_start(struct qcom_pas_data *data)
+{
+	vaddr_t base = io_pa_or_va(&data->base, data->size);
+
+	if (!base)
+		return TEE_ERROR_GENERIC;
+
+	/*
+	 * Program the firmware entry address and select the programmed EVB;
+	 */
+	io_write32(base + HPASS_QDSP6SS_RST_EVB, data->fw_base >> 4);
+	io_write32(base + HPASS_EFUSE_Q6SS_EVB_SEL, 0);
+	dsb();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result hpass_fw_shutdown(struct qcom_pas_data *data __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static TEE_Result hpass_get_resource_table(struct resource_table *rt,
+					   size_t *rt_size)
+{
+	const struct fw_rsc_hdr header = {
+		.type = RSC_DEVMEM,
+	};
+	static struct resource_table table = {
+		.ver = 1,
+		.num = HPASS_NUM_MEM_RESOURCES,
+		.offset[RESOURCE_TABLE_OFFSET_LAST(HPASS)] = 0,
+	};
+
+	return get_mem_rsc(rt, rt_size, &table, &header,
+			   hpass_mem_res,
+			   HPASS_RESOURCE_TABLE_HEADER_SIZE,
+			   HPASS_RESOURCE_TABLE_SIZE);
+}
+
+const struct qcom_pas_ops hpass0_ops = {
+	.fw_start = hpass_fw_start,
+	.fw_shutdown = hpass_fw_shutdown,
+	.get_resource_table = hpass_get_resource_table,
+};

--- a/core/pta/qcom/pas/platform/nord/hpass0.h
+++ b/core/pta/qcom/pas/platform/nord/hpass0.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _HPASS0_H_
+#define _HPASS0_H_
+
+#include "pas_subsys.h"
+
+extern const struct qcom_pas_ops hpass0_ops;
+
+#endif /* _HPASS0_H_ */

--- a/core/pta/qcom/pas/platform/nord/hpass1.c
+++ b/core/pta/qcom/pas/platform/nord/hpass1.c
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <io.h>
+#include <platform_config.h>
+#include <resource_table.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "hpass1.h"
+
+/*
+ * QDSP6 boot registers for each HPS instance. The PUB block
+ * holds the reset/boot FSM registers; the TCSR block holds the EVB select.
+ */
+#define HPASS_BASE_OFFSET				(0x2000000)
+#define HPASS_TCSR_REGS_REG_OFFSET		(0x1580000)
+
+#define HPASS_QDSP6SS_RST_EVB			(0x10)
+
+#define HPASS_TCSR_EVB_SEL_OFFSET		(0x3000)
+#define HPASS_TCSR_EVB_SEL_STRIDE		(0x1000)
+#define HPASS_INSTANCE_IDX				(0x1)
+
+#define HPASS_EFUSE_Q6SS_EVB_SEL		(HPASS_TCSR_REGS_REG_OFFSET - HPASS_BASE_OFFSET + \
+						 HPASS_TCSR_EVB_SEL_OFFSET + \
+						 (HPASS_TCSR_EVB_SEL_STRIDE * HPASS_INSTANCE_IDX))
+
+#define BOOT_FSM_TIMEOUT				(10000)
+
+static const struct fw_rsc_devmem hpass_mem_res[] = { };
+
+DEFINE_RESOURCE_TABLE(HPASS, ARRAY_SIZE(hpass_mem_res));
+
+static TEE_Result hpass_fw_start(struct qcom_pas_data *data)
+{
+	vaddr_t base = io_pa_or_va(&data->base, data->size);
+
+	if (!base)
+		return TEE_ERROR_GENERIC;
+
+	/*
+	 * Program the firmware entry address and select the programmed EVB;
+	 */
+	io_write32(base + HPASS_QDSP6SS_RST_EVB, data->fw_base >> 4);
+	io_write32(base + HPASS_EFUSE_Q6SS_EVB_SEL, 0);
+	dsb();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result hpass_fw_shutdown(struct qcom_pas_data *data __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static TEE_Result hpass_get_resource_table(struct resource_table *rt,
+					   size_t *rt_size)
+{
+	const struct fw_rsc_hdr header = {
+		.type = RSC_DEVMEM,
+	};
+	static struct resource_table table = {
+		.ver = 1,
+		.num = HPASS_NUM_MEM_RESOURCES,
+		.offset[RESOURCE_TABLE_OFFSET_LAST(HPASS)] = 0,
+	};
+
+	return get_mem_rsc(rt, rt_size, &table, &header,
+			   hpass_mem_res,
+			   HPASS_RESOURCE_TABLE_HEADER_SIZE,
+			   HPASS_RESOURCE_TABLE_SIZE);
+}
+
+const struct qcom_pas_ops hpass1_ops = {
+	.fw_start = hpass_fw_start,
+	.fw_shutdown = hpass_fw_shutdown,
+	.get_resource_table = hpass_get_resource_table,
+};

--- a/core/pta/qcom/pas/platform/nord/hpass1.h
+++ b/core/pta/qcom/pas/platform/nord/hpass1.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _HPASS1_H_
+#define _HPASS1_H_
+
+#include "pas_subsys.h"
+
+extern const struct qcom_pas_ops hpass1_ops;
+
+#endif /* _HPASS1_H_ */

--- a/core/pta/qcom/pas/platform/nord/hpass2.c
+++ b/core/pta/qcom/pas/platform/nord/hpass2.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <io.h>
+#include <platform_config.h>
+#include <resource_table.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "hpass2.h"
+
+/*
+ * QDSP6 boot registers for each HPS instance. The PUB block
+ * holds the reset/boot FSM registers; the TCSR block holds the EVB select.
+ */
+#define HPASS_BASE_OFFSET				(0x2100000)
+#define HPASS_TCSR_REGS_REG_OFFSET		(0x1580000)
+
+#define HPASS_QDSP6SS_RST_EVB			(0x10)
+
+#define HPASS_TCSR_EVB_SEL_OFFSET		(0x3000)
+#define HPASS_TCSR_EVB_SEL_STRIDE		(0x1000)
+#define HPASS_INSTANCE_IDX				(0x2)
+
+#define HPASS_EFUSE_Q6SS_EVB_SEL		(HPASS_TCSR_REGS_REG_OFFSET - HPASS_BASE_OFFSET + \
+						 HPASS_TCSR_EVB_SEL_OFFSET + \
+						 (HPASS_TCSR_EVB_SEL_STRIDE * HPASS_INSTANCE_IDX))
+
+#define BOOT_FSM_TIMEOUT				(10000)
+
+static const struct fw_rsc_devmem hpass_mem_res[] = { };
+
+DEFINE_RESOURCE_TABLE(HPASS, ARRAY_SIZE(hpass_mem_res));
+
+static TEE_Result hpass_fw_start(struct qcom_pas_data *data)
+{
+	vaddr_t base = io_pa_or_va(&data->base, data->size);
+
+	if (!base)
+		return TEE_ERROR_GENERIC;
+
+	/*
+	 * Program the firmware entry address and select the programmed EVB;
+	 * the Q6 PLL and core RCG are already configured by hpass_setup().
+	 */
+	io_write32(base + HPASS_QDSP6SS_RST_EVB, data->fw_base >> 4);
+	io_write32(base + HPASS_EFUSE_Q6SS_EVB_SEL, 0);
+	dsb();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result hpass_fw_shutdown(struct qcom_pas_data *data __unused)
+{
+	return TEE_ERROR_NOT_IMPLEMENTED;
+}
+
+static TEE_Result hpass_get_resource_table(struct resource_table *rt,
+					   size_t *rt_size)
+{
+	const struct fw_rsc_hdr header = {
+		.type = RSC_DEVMEM,
+	};
+	static struct resource_table table = {
+		.ver = 1,
+		.num = HPASS_NUM_MEM_RESOURCES,
+		.offset[RESOURCE_TABLE_OFFSET_LAST(HPASS)] = 0,
+	};
+
+	return get_mem_rsc(rt, rt_size, &table, &header,
+			   hpass_mem_res,
+			   HPASS_RESOURCE_TABLE_HEADER_SIZE,
+			   HPASS_RESOURCE_TABLE_SIZE);
+}
+
+const struct qcom_pas_ops hpass2_ops = {
+	.fw_start = hpass_fw_start,
+	.fw_shutdown = hpass_fw_shutdown,
+	.get_resource_table = hpass_get_resource_table,
+};

--- a/core/pta/qcom/pas/platform/nord/hpass2.h
+++ b/core/pta/qcom/pas/platform/nord/hpass2.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _HPASS2_H_
+#define _HPASS2_H_
+
+#include "pas_subsys.h"
+
+extern const struct qcom_pas_ops hpass2_ops;
+
+#endif /* _HPASS2_H_ */

--- a/core/pta/qcom/pas/platform/nord/nspss0.c
+++ b/core/pta/qcom/pas/platform/nord/nspss0.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <io.h>
+#include <kernel/cache_helpers.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <resource_table.h>
+#include <stdint.h>
+#include <string.h>
+#include <trace.h>
+
+#include "nspss0.h"
+
+#define NSPSS_QDSP6SS_RST_EVB		(0x10)
+
+static const struct fw_rsc_devmem nspss_mem_res[] = { };
+
+DEFINE_RESOURCE_TABLE(NSPSS, ARRAY_SIZE(nspss_mem_res));
+
+#define BOOT_FSM_TIMEOUT	10000
+
+
+static TEE_Result nspss0_fw_start(struct qcom_pas_data *data)
+{
+	vaddr_t base = io_pa_or_va(&data->base, data->size);
+
+	/* Program firmware */
+	io_write32(base + NSPSS_QDSP6SS_RST_EVB, data->fw_base >> 4);
+	dsb();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result nspss0_fw_shutdown(struct qcom_pas_data *data)
+{
+	return qcom_clock_pas_reset(data->clk_group);
+}
+
+static TEE_Result nspss0_get_resource_table(struct resource_table *rt,
+					   size_t *rt_size)
+{
+	const struct fw_rsc_hdr header = {
+		.type = RSC_DEVMEM,
+	};
+	static struct resource_table table = {
+		.ver = 1,
+		.num = NSPSS_NUM_MEM_RESOURCES,
+		.offset[RESOURCE_TABLE_OFFSET_LAST(NSPSS)] = 0,
+	};
+
+	return get_mem_rsc(rt, rt_size, &table, &header,
+			   nspss_mem_res,
+			   NSPSS_RESOURCE_TABLE_HEADER_SIZE,
+			   NSPSS_RESOURCE_TABLE_SIZE);
+}
+
+const struct qcom_pas_ops nspss0_ops = {
+	.fw_start = nspss0_fw_start,
+	.fw_shutdown = nspss0_fw_shutdown,
+	.get_resource_table = nspss0_get_resource_table,
+};

--- a/core/pta/qcom/pas/platform/nord/nspss0.h
+++ b/core/pta/qcom/pas/platform/nord/nspss0.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _NSPSS0_H_
+#define _NSPSS0_H_
+
+#include "pas_subsys.h"
+
+extern const struct qcom_pas_ops nspss0_ops;
+
+#endif /* _NSPSS0_H_ */

--- a/core/pta/qcom/pas/platform/nord/nspss1.c
+++ b/core/pta/qcom/pas/platform/nord/nspss1.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <io.h>
+#include <kernel/cache_helpers.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <resource_table.h>
+#include <stdint.h>
+#include <string.h>
+#include <trace.h>
+
+#include "nspss1.h"
+
+#define NSPSS_QDSP6SS_RST_EVB		(0x10)
+
+static const struct fw_rsc_devmem nspss_mem_res[] = { };
+
+DEFINE_RESOURCE_TABLE(NSPSS, ARRAY_SIZE(nspss_mem_res));
+
+#define BOOT_FSM_TIMEOUT	10000
+
+
+static TEE_Result nspss1_fw_start(struct qcom_pas_data *data)
+{
+	vaddr_t base = io_pa_or_va(&data->base, data->size);
+
+	/* Program firmware */
+	io_write32(base + NSPSS_QDSP6SS_RST_EVB, data->fw_base >> 4);
+	dsb();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result nspss1_fw_shutdown(struct qcom_pas_data *data)
+{
+	return qcom_clock_pas_reset(data->clk_group);
+}
+
+static TEE_Result nspss1_get_resource_table(struct resource_table *rt,
+					   size_t *rt_size)
+{
+	const struct fw_rsc_hdr header = {
+		.type = RSC_DEVMEM,
+	};
+	static struct resource_table table = {
+		.ver = 1,
+		.num = NSPSS_NUM_MEM_RESOURCES,
+		.offset[RESOURCE_TABLE_OFFSET_LAST(NSPSS)] = 0,
+	};
+
+	return get_mem_rsc(rt, rt_size, &table, &header,
+			   nspss_mem_res,
+			   NSPSS_RESOURCE_TABLE_HEADER_SIZE,
+			   NSPSS_RESOURCE_TABLE_SIZE);
+}
+
+const struct qcom_pas_ops nspss1_ops = {
+	.fw_start = nspss1_fw_start,
+	.fw_shutdown = nspss1_fw_shutdown,
+	.get_resource_table = nspss1_get_resource_table,
+};

--- a/core/pta/qcom/pas/platform/nord/nspss1.h
+++ b/core/pta/qcom/pas/platform/nord/nspss1.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _NSPSS1_H_
+#define _NSPSS1_H_
+
+#include "pas_subsys.h"
+
+extern const struct qcom_pas_ops nspss1_ops;
+
+#endif /* _NSPSS1_H_ */

--- a/core/pta/qcom/pas/platform/nord/nspss2.c
+++ b/core/pta/qcom/pas/platform/nord/nspss2.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <io.h>
+#include <kernel/cache_helpers.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <resource_table.h>
+#include <stdint.h>
+#include <string.h>
+#include <trace.h>
+
+#include "nspss2.h"
+
+#define NSPSS_QDSP6SS_RST_EVB		(0x10)
+
+static const struct fw_rsc_devmem nspss_mem_res[] = { };
+
+DEFINE_RESOURCE_TABLE(NSPSS, ARRAY_SIZE(nspss_mem_res));
+
+#define BOOT_FSM_TIMEOUT	10000
+
+
+static TEE_Result nspss2_fw_start(struct qcom_pas_data *data)
+{
+	vaddr_t base = io_pa_or_va(&data->base, data->size);
+
+	/* Program firmware */
+	io_write32(base + NSPSS_QDSP6SS_RST_EVB, data->fw_base >> 4);
+	dsb();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result nspss2_fw_shutdown(struct qcom_pas_data *data)
+{
+	return qcom_clock_pas_reset(data->clk_group);
+}
+
+static TEE_Result nspss2_get_resource_table(struct resource_table *rt,
+					   size_t *rt_size)
+{
+	const struct fw_rsc_hdr header = {
+		.type = RSC_DEVMEM,
+	};
+	static struct resource_table table = {
+		.ver = 1,
+		.num = NSPSS_NUM_MEM_RESOURCES,
+		.offset[RESOURCE_TABLE_OFFSET_LAST(NSPSS)] = 0,
+	};
+
+	return get_mem_rsc(rt, rt_size, &table, &header,
+			   nspss_mem_res,
+			   NSPSS_RESOURCE_TABLE_HEADER_SIZE,
+			   NSPSS_RESOURCE_TABLE_SIZE);
+}
+
+const struct qcom_pas_ops nspss2_ops = {
+	.fw_start = nspss2_fw_start,
+	.fw_shutdown = nspss2_fw_shutdown,
+	.get_resource_table = nspss2_get_resource_table,
+};

--- a/core/pta/qcom/pas/platform/nord/nspss2.h
+++ b/core/pta/qcom/pas/platform/nord/nspss2.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _NSPSS2_H_
+#define _NSPSS2_H_
+
+#include "pas_subsys.h"
+
+extern const struct qcom_pas_ops nspss2_ops;
+
+#endif /* _NSPSS2_H_ */

--- a/core/pta/qcom/pas/platform/nord/nspss3.c
+++ b/core/pta/qcom/pas/platform/nord/nspss3.c
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <io.h>
+#include <kernel/cache_helpers.h>
+#include <mm/core_memprot.h>
+#include <mm/core_mmu.h>
+#include <platform_config.h>
+#include <resource_table.h>
+#include <stdint.h>
+#include <string.h>
+#include <trace.h>
+
+#include "nspss3.h"
+
+#define NSPSS_QDSP6SS_RST_EVB		(0x10)
+
+static const struct fw_rsc_devmem nspss_mem_res[] = { };
+
+DEFINE_RESOURCE_TABLE(NSPSS, ARRAY_SIZE(nspss_mem_res));
+
+#define BOOT_FSM_TIMEOUT	10000
+
+
+static TEE_Result nspss3_fw_start(struct qcom_pas_data *data)
+{
+	vaddr_t base = io_pa_or_va(&data->base, data->size);
+
+	/* Program firmware */
+	io_write32(base + NSPSS_QDSP6SS_RST_EVB, data->fw_base >> 4);
+	dsb();
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result nspss3_fw_shutdown(struct qcom_pas_data *data)
+{
+	return qcom_clock_pas_reset(data->clk_group);
+}
+
+static TEE_Result nspss3_get_resource_table(struct resource_table *rt,
+					   size_t *rt_size)
+{
+	const struct fw_rsc_hdr header = {
+		.type = RSC_DEVMEM,
+	};
+	static struct resource_table table = {
+		.ver = 1,
+		.num = NSPSS_NUM_MEM_RESOURCES,
+		.offset[RESOURCE_TABLE_OFFSET_LAST(NSPSS)] = 0,
+	};
+
+	return get_mem_rsc(rt, rt_size, &table, &header,
+			   nspss_mem_res,
+			   NSPSS_RESOURCE_TABLE_HEADER_SIZE,
+			   NSPSS_RESOURCE_TABLE_SIZE);
+}
+
+const struct qcom_pas_ops nspss3_ops = {
+	.fw_start = nspss3_fw_start,
+	.fw_shutdown = nspss3_fw_shutdown,
+	.get_resource_table = nspss3_get_resource_table,
+};

--- a/core/pta/qcom/pas/platform/nord/nspss3.h
+++ b/core/pta/qcom/pas/platform/nord/nspss3.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#ifndef _NSPSS3_H_
+#define _NSPSS3_H_
+
+#include "pas_subsys.h"
+
+extern const struct qcom_pas_ops nspss3_ops;
+
+#endif /* _NSPSS3_H_ */

--- a/core/pta/qcom/pas/platform/nord/sub.mk
+++ b/core/pta/qcom/pas/platform/nord/sub.mk
@@ -1,0 +1,3 @@
+srcs-y += subsys.c hpass0.c hpass1.c hpass2.c nspss0.c nspss1.c nspss2.c nspss3.c
+incdirs-y += .
+incdirs-y += ../

--- a/core/pta/qcom/pas/platform/nord/subsys.c
+++ b/core/pta/qcom/pas/platform/nord/subsys.c
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2026, Qualcomm Technologies, Inc. and/or its subsidiaries.
+ */
+
+#include <platform_config.h>
+#include <pta_qcom_pas.h>
+#include <stddef.h>
+#include <util.h>
+
+#include "nspss0.h"
+#include "nspss1.h"
+#include "nspss2.h"
+#include "nspss3.h"
+#include "hpass0.h"
+#include "hpass1.h"
+#include "hpass2.h"
+#include "pas_subsys.h"
+
+static struct qcom_pas_subsys subsystems[] = {
+	{
+		.data = {
+			.pas_id = PAS_ID_TURING,
+			.base.pa = CDSP_0_BASE,
+			.size = CDSP_0_SIZE,
+			.clk_group = QCOM_CLKS_TURING,
+		},
+		.ops = &nspss0_ops,
+		.reset_seq = QCOM_PAS_RESET_CLK_FULL,
+	},
+	{
+		.data = {
+			.pas_id = PAS_ID_TURING1,
+			.base.pa = CDSP_1_BASE,
+			.size = CDSP_1_SIZE,
+			.clk_group = QCOM_CLKS_TURING1,
+		},
+		.ops = &nspss1_ops,
+		.reset_seq = QCOM_PAS_RESET_CLK_FULL,
+	},
+	{
+		.data = {
+			.pas_id = PAS_ID_TURING2,
+			.base.pa = CDSP_2_BASE,
+			.size = CDSP_2_SIZE,
+			.clk_group = QCOM_CLKS_TURING2,
+		},
+		.ops = &nspss2_ops,
+		.reset_seq = QCOM_PAS_RESET_CLK_FULL,
+	},
+	{
+		.data = {
+			.pas_id = PAS_ID_TURING3,
+			.base.pa = CDSP_3_BASE,
+			.size = CDSP_3_SIZE,
+			.clk_group = QCOM_CLKS_TURING3,
+		},
+		.ops = &nspss3_ops,
+		.reset_seq = QCOM_PAS_RESET_CLK_FULL,
+	},
+	{
+		.data = {
+			.pas_id = PAS_ID_QDSP6,
+			.base.pa = HPASS_0_BASE,
+			.size = HPASS_0_SIZE,
+			.clk_group = QCOM_CLKS_HPASS0,
+		},
+		.ops = &hpass0_ops,
+		.reset_seq = QCOM_PAS_RESET_CLK_FULL,
+	},
+	{
+		.data = {
+			.pas_id = PAS_ID_HPASS1,
+			.base.pa = HPASS_1_BASE,
+			.size = HPASS_1_SIZE,
+			.clk_group = QCOM_CLKS_HPASS1,
+		},
+		.ops = &hpass1_ops,
+		.reset_seq = QCOM_PAS_RESET_CLK_FULL,
+	},
+	{
+		.data = {
+			.pas_id = PAS_ID_HPASS2,
+			.base.pa = HPASS_2_BASE,
+			.size = HPASS_2_SIZE,
+			.clk_group = QCOM_CLKS_HPASS2,
+		},
+		.ops = &hpass2_ops,
+		.reset_seq = QCOM_PAS_RESET_CLK_FULL,
+	},
+};
+
+struct qcom_pas_subsys *qcom_pas_platform_subsys(size_t *count)
+{
+	*count = ARRAY_SIZE(subsystems);
+
+	return subsystems;
+}

--- a/core/pta/qcom/pas/platform/resource_table.h
+++ b/core/pta/qcom/pas/platform/resource_table.h
@@ -63,6 +63,19 @@
 	}
 
 /*
+ * RESOURCE_TABLE_OFFSET_LAST(prefix) : last valid index into the offset[]
+ * flexible array member for a table with PREFIX_NUM_MEM_RESOURCES entries.
+ *
+ * Use as the designator in the table initialiser, e.g.
+ * ".offset[RESOURCE_TABLE_OFFSET_LAST(prefix)] = 0", to force the compiler
+ * to reserve storage for all entries. Clamped to 0 when there are no
+ * entries, so a table with an empty mem_res array still compiles instead of
+ * indexing offset[-1].
+ */
+#define RESOURCE_TABLE_OFFSET_LAST(prefix) \
+	(prefix##_NUM_MEM_RESOURCES ? (prefix##_NUM_MEM_RESOURCES - 1) : 0)
+
+/*
  * resource_table : top-level header of the firmware resource table.
  *
  * @ver:      Table version; must be 1.


### PR DESCRIPTION
Register the PAS bring-up for Nord's subsystems HPASS & NSPSS.
- hpass0-2: program the HPASS reset-EVB and TCSR EVB-select registers for each HPASS instance from its own base offset and TCSR stride index.
- nspss0-3: program the NSPSS reset-EVB register for each CDSP instance.
- subsys.c: register all subsystems (HPASS0-2, NSPSS0-3) with their PAS IDs, base/size and clock groups.

<!--
    If you are new to submitting pull requests to OP-TEE, then please have a
    look at the list below and tick them off before submitting the pull request.

    1. Read our contribution guidelines:
         https://optee.readthedocs.io/en/latest/general/contribute.html

    2. Read the contribution section in Notice.md and pay extra attention to the
       "Developer Certificate of Origin" in the contribution guidelines.

    3. You should run checkpatch preferably before submitting the pull request.

    4. When everything has been reviewed, you will need to squash, rebase and
       add tags like `Reviewed-by`, `Acked-by`, `Tested-by` etc. More details
       about this can also be found on the link provided above.

    NOTE: This comment will not be shown in the pull request, so no harm keeping
    it, but feel free to remove it if you like.
-->
